### PR TITLE
Prepare ramani for 0.1.1 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Get patched annotation plugin
-        run: git clone https://github.com/ramani-maps/maplibre-plugins-android
-      - name: Setup composite build
-        run: echo "includeBuild '../maplibre-plugins-android/plugin-annotation'" >> ramani/settings.gradle
       - name: Build
         working-directory: ./ramani
         run: |
@@ -51,8 +47,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Get patched annotation plugin
-        run: git -C .. clone https://github.com/ramani-maps/maplibre-plugins-android
+      - name: Use ramani as composite build
+        working-directory: ./examples/annotation-simple
+        run: echo "includeBuild '../../ramani'" >> settings.gradle
       - name: Build
         working-directory: ./examples/annotation-simple
         run: |
@@ -71,8 +68,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Get patched annotation plugin
-        run: git -C .. clone https://github.com/ramani-maps/maplibre-plugins-android
+      - name: Use ramani as composite build
+        working-directory: ./examples/interactive-polygon
+        run: echo "includeBuild '../../ramani'" >> settings.gradle
       - name: Build
         working-directory: ./examples/interactive-polygon
         run: |

--- a/examples/annotation-simple/app/build.gradle
+++ b/examples/annotation-simple/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
-    implementation 'org.ramani-maps:ramani-maplibre:0.1.0'
+    implementation 'org.ramani-maps:ramani-maplibre:0.1.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/examples/annotation-simple/settings.gradle
+++ b/examples/annotation-simple/settings.gradle
@@ -15,4 +15,6 @@ dependencyResolutionManagement {
 rootProject.name = "AnnotationSimple"
 include ':app'
 
-includeBuild '../../ramani'
+// Uncomment to use Ramani as a composite build (for dev purposes)
+//includeBuild '../../ramani'
+

--- a/examples/interactive-polygon/app/build.gradle
+++ b/examples/interactive-polygon/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
-    implementation 'org.ramani-maps:ramani-maplibre:0.1.0'
+    implementation 'org.ramani-maps:ramani-maplibre:0.1.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/examples/interactive-polygon/settings.gradle
+++ b/examples/interactive-polygon/settings.gradle
@@ -15,4 +15,6 @@ dependencyResolutionManagement {
 rootProject.name = "InteractivePolygon"
 include ':app'
 
-includeBuild '../../ramani'
+// Uncomment to use Ramani as a composite build (for dev purposes)
+//includeBuild '../../ramani'
+


### PR DESCRIPTION
* Stop using the composite build for annotation-plugin in the CI
* Have example default to ramani 0.1.1 from Maven (not composite build)
* Have the CI build the examples with raman from the repo, as a composite build