### PR TITLE
Move annotation example to mapbox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,12 +47,19 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Set mapbox token for ramani
+        working-directory: ./ramani-mapbox
+        run: |
+            echo "MAPBOX_API_KEY=${{ secrets.MAPBOX_TOKEN }}" >> keystore.properties
+            echo "MAPBOX_DOWNLOAD_TOKEN=${{ secrets.MAPBOX_TOKEN }}" >> keystore.properties
       - name: Use ramani as composite build
         working-directory: ./examples/annotation-simple
-        run: echo "includeBuild '../../ramani-maplibre'" >> settings.gradle
+        run: echo "includeBuild '../../ramani-mapbox'" >> settings.gradle
       - name: Build
         working-directory: ./examples/annotation-simple
         run: |
+            echo "MAPBOX_API_KEY=${{ secrets.MAPBOX_TOKEN }}" >> keystore.properties
+            echo "MAPBOX_DOWNLOAD_TOKEN=${{ secrets.MAPBOX_TOKEN }}" >> keystore.properties
             ./gradlew build
             ./gradlew test
 

--- a/examples/annotation-simple/app/build.gradle
+++ b/examples/annotation-simple/app/build.gradle
@@ -3,6 +3,15 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 }
 
+// Load file "keystore.properties" where we keep our keys
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+def keystoreProperties = new Properties()
+
+try {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+} catch (IOException ignored) {
+}
+
 android {
     namespace 'org.ramani.example.annotation_simple'
     compileSdk 33
@@ -13,6 +22,13 @@ android {
         targetSdk 33
         versionCode 1
         versionName "1.0"
+
+        if (keystoreProperties.containsKey("MAPBOX_API_KEY")) {
+            resValue "string", "mapbox_api_key", keystoreProperties["MAPBOX_API_KEY"]
+        } else {
+            println("WARNING: MAPBOX_API_KEY is missing from keystore file!")
+            resValue "string", "mapbox_api_key", ""
+        }
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -55,7 +71,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
-    implementation 'org.ramani-maps:ramani-maplibre:0.1.1'
+    implementation 'org.ramani-maps:ramani-mapbox:0.0.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/examples/annotation-simple/app/src/main/java/org/ramani/example/annotation_simple/MainActivity.kt
+++ b/examples/annotation-simple/app/src/main/java/org/ramani/example/annotation_simple/MainActivity.kt
@@ -10,9 +10,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.ramani.compose.CameraPosition
+import org.ramani.compose.CameraPositionState
 import org.ramani.compose.Circle
-import org.ramani.compose.MapLibre
+import org.ramani.compose.LatLng
+import org.ramani.compose.Mapbox
 import org.ramani.compose.Polyline
 import org.ramani.example.annotation_simple.ui.theme.AnnotationSimpleTheme
 
@@ -27,7 +29,16 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    MapLibre(modifier = Modifier.fillMaxSize(), apiKey = "2z0TwvuXjwgOpvle5GYY") {
+                    Mapbox(
+                        modifier = Modifier.fillMaxSize(),
+                        apiKey = resources.getString(R.string.mapbox_api_key),
+                        cameraPositionState = CameraPositionState(
+                            CameraPosition(
+                                target = LatLng(4.8, 46.0),
+                                zoom = 2.0,
+                            )
+                        ),
+                    ) {
                         Circle(
                             center = LatLng(4.8, 46.0),
                             radius = 50F,

--- a/examples/annotation-simple/settings.gradle
+++ b/examples/annotation-simple/settings.gradle
@@ -5,9 +5,33 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+def keystorePropertiesFile
+for (file in getRootProject().getProjectDir().listFiles()) {
+    if (file.name == "keystore.properties") {
+        keystorePropertiesFile = file
+    }
+}
+def keystoreProperties = new Properties()
+keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        maven {
+            url 'https://api.mapbox.com/downloads/v2/releases/maven'
+            authentication {
+                basic(BasicAuthentication)
+            }
+            credentials {
+                // Do not change the username below.
+                // This should always be `mapbox` (not your username).
+                username = "mapbox"
+                // Use the secret token you stored in gradle.properties as the password
+                password = keystoreProperties["MAPBOX_DOWNLOAD_TOKEN"]
+            }
+        }
+
         google()
         mavenCentral()
     }
@@ -16,5 +40,4 @@ rootProject.name = "AnnotationSimple"
 include ':app'
 
 // Uncomment to use Ramani as a composite build (for dev purposes)
-//includeBuild '../../ramani'
-
+//includeBuild '../../ramani-mapbox'


### PR DESCRIPTION
The code is almost exactly the same as for ramani-maplibre, so the idea is to have one example with mapbox, and one with maplibre.