### PR TITLE
Add CI for ramani-mapbox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
     types: [created]
 
 jobs:
-  ramani:
+  ramani-maplibre:
     name: Build and test ramani-maplibre
     runs-on: ubuntu-22.04
     steps:
@@ -34,6 +34,32 @@ jobs:
         run: |
             echo -n "${{ secrets.MAVEN_SIGNING_KEY }}" | base64 --decode | gpg --import
             ./gradlew -PossrhUsername=${{ secrets.OSSRH_USERNAME }} -PossrhPassword=${{ secrets.OSSRH_PASSWORD }} publish
+
+  ramani-mapbox:
+    name: Build and test ramani-mapbox
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build
+        working-directory: ./ramani-mapbox
+        run: |
+            echo "MAPBOX_API_KEY=${{ secrets.MAPBOX_TOKEN }}" >> keystore.properties
+            echo "MAPBOX_DOWNLOAD_TOKEN=${{ secrets.MAPBOX_TOKEN }}" >> keystore.properties
+            ./gradlew build
+            ./gradlew test
+#      - name: Publish (Maven)
+#        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
+#        working-directory: ./ramani-mapbox
+#        run: |
+#            echo -n "${{ secrets.MAVEN_SIGNING_KEY }}" | base64 --decode | gpg --import
+#            ./gradlew -PossrhUsername=${{ secrets.OSSRH_USERNAME }} -PossrhPassword=${{ secrets.OSSRH_PASSWORD }} publish
 
   annotation-simple:
     name: "Build and test example: AnnotationSimple"


### PR DESCRIPTION
Now that we have two Maven artifacts (ramani-maplibre and ramani-mapbox), we can't really use the Github releases the same way. But I feel like we can just leverage tags, and that should be fine.

The alternative is to split them in two repos, but I'd like to keep them in the same repo if possible (seems like having two repos adds overhead and that's annoying).