### PR TITLE
mapbox: fix drag outside screen

### DIFF
--- a/ramani-mapbox/src/main/java/org/ramani/compose/CoordToPixelMapper.kt
+++ b/ramani-mapbox/src/main/java/org/ramani/compose/CoordToPixelMapper.kt
@@ -18,7 +18,12 @@ import com.mapbox.maps.ScreenCoordinate
 @Composable
 fun pixelFromCoord(coord: LatLng): ScreenCoordinate {
     val mapApplier = currentComposer.applier as MapApplier
-    return mapApplier.map.pixelForCoordinate(Point.fromLngLat(coord.longitude, coord.latitude))
+
+    // We use `pixelsForCoordinates` instead of `pixelForCoordinate` here because Mapbox makes
+    // a weird test in the latter, returning (-1, -1) when the coordinate is not on the screen.
+    // `pixelsForCoordinates` works as expected.
+    val coordList = listOf(Point.fromLngLat(coord.longitude, coord.latitude))
+    return mapApplier.map.pixelsForCoordinates(coordList)[0]
 }
 
 @Composable

--- a/ramani-mapbox/src/main/java/org/ramani/compose/Polygon.kt
+++ b/ramani-mapbox/src/main/java/org/ramani/compose/Polygon.kt
@@ -29,39 +29,27 @@ private fun VertexDragger(
         return
     }
 
-    val mapApplier = currentComposer.applier as MapApplier
-    val map = mapApplier.map
-
     var currentCenter = ScreenCoordinate(0.0, 0.0)
-    vertices.forEach { currentCenter += map.pixelForCoordinate(it.toPoint()) }
+    vertices.forEach { currentCenter += pixelFromCoord(it) }
 
     currentCenter = ScreenCoordinate(
         currentCenter.x / vertices.size,
         currentCenter.y / vertices.size
     )
 
-    val newCenter = map.pixelForCoordinate(draggedCenter.toPoint())
+    val newCenter = pixelFromCoord(draggedCenter)
     val draggedPixels = newCenter - currentCenter
     val draggedVertices = vertices
         .map { vertex ->
-            val screenVertex = map.pixelForCoordinate(vertex.toPoint())
+            val screenVertex = pixelFromCoord(vertex)
             val afterDrag = screenVertex + draggedPixels
-            map.coordinateForPixel(afterDrag)
+            coordFromPixel(afterDrag)
         }
-        .map { pointToLatLng(it) }
 
     onCenterAndVerticesChanged(
-        pointToLatLng(map.coordinateForPixel(currentCenter)),
+        coordFromPixel(currentCenter),
         draggedVertices
     )
-}
-
-private fun LatLng.toPoint(): Point {
-    return Point.fromLngLat(this.longitude, this.latitude)
-}
-
-private fun pointToLatLng(point: Point): LatLng {
-    return LatLng(point.latitude(), point.longitude())
 }
 
 @Composable


### PR DESCRIPTION
For some reason, Mapbox does not allow the coordinate to be outside the screen (but still on the map) when using [`pixelForCoordinates`](https://github.com/mapbox/mapbox-maps-android/blob/main/sdk/src/public/java/com/mapbox/maps/MapboxMap.kt#L795-L799):

```kotlin
    return if (coordinate.x in 0.0..screenSize.width.toDouble() && coordinate.y in 0.0..screenSize.height.toDouble()) {
      coordinate
    } else {
      ScreenCoordinate(-1.0, -1.0)
    }
```

However, [`pixelsForCoordinates`](https://github.com/mapbox/mapbox-maps-android/blob/main/sdk/src/public/java/com/mapbox/maps/MapboxMap.kt#L820-L823) does what I would expect:

```kotlin
  override fun pixelsForCoordinates(coordinates: List<Point>): List<ScreenCoordinate> {
    checkNativeMap("pixelsForCoordinates")
    return nativeMap.pixelsForCoordinates(coordinates)
  }
```