### PR TITLE
maplibre: Improve lifecycle for camera position

### DIFF
--- a/examples/interactive-polygon/app/src/main/java/org/ramani/example/interactive_polygon/MainActivity.kt
+++ b/examples/interactive-polygon/app/src/main/java/org/ramani/example/interactive_polygon/MainActivity.kt
@@ -11,14 +11,12 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.neverEqualPolicy
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.mapbox.mapboxsdk.geometry.LatLng
 import org.ramani.compose.CameraPosition
-import org.ramani.compose.CameraPositionState
 import org.ramani.compose.Circle
 import org.ramani.compose.MapLibre
 import org.ramani.compose.Polygon
@@ -29,13 +27,10 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             InteractivePolygonTheme {
-                var polygonState by remember { mutableStateOf(polygonPoints) }
                 var polygonCenter = LatLng(44.989, 10.809)
-                var cameraPosition by remember {
-                    mutableStateOf(
-                        CameraPosition(target = polygonCenter, zoom = 15.0),
-                        neverEqualPolicy()
-                    )
+                var polygonState by rememberSaveable { mutableStateOf(polygonPoints) }
+                val cameraPosition = rememberSaveable {
+                    mutableStateOf(CameraPosition(target = polygonCenter, zoom = 15.0))
                 }
 
                 Box {
@@ -46,7 +41,7 @@ class MainActivity : ComponentActivity() {
                         MapLibre(
                             modifier = Modifier.fillMaxSize(),
                             apiKey = resources.getString(R.string.maplibre_api_key),
-                            cameraPositionState = CameraPositionState(cameraPosition),
+                            cameraPosition = cameraPosition.value
                         ) {
                             polygonState.forEachIndexed { index, vertex ->
                                 Circle(
@@ -78,7 +73,9 @@ class MainActivity : ComponentActivity() {
                     Button(
                         modifier = Modifier.align(Alignment.BottomCenter),
                         onClick = {
-                            cameraPosition = CameraPosition(target = polygonCenter)
+                            cameraPosition.value = CameraPosition(cameraPosition.value).apply {
+                                this.target = polygonCenter
+                            }
                         },
                     ) {
                         Text(text = "Center on polygon")

--- a/ramani-maplibre/src/main/java/org/ramani/compose/CameraPositionState.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/CameraPositionState.kt
@@ -12,9 +12,6 @@ package org.ramani.compose
 
 import android.os.Parcel
 import android.os.Parcelable
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
 import com.mapbox.mapboxsdk.geometry.LatLng
 
 data class CameraPosition(
@@ -57,21 +54,4 @@ data class CameraPosition(
             return arrayOfNulls(size)
         }
     }
-}
-
-class CameraPositionState(var cameraPosition: CameraPosition = CameraPosition()) {
-    companion object {
-        val Saver: Saver<CameraPositionState, CameraPosition> = Saver(
-            save = { it.cameraPosition },
-            restore = { CameraPositionState(it) }
-        )
-    }
-}
-
-@Composable
-inline fun rememberCameraPositionState(
-    key: String? = null,
-    crossinline init: CameraPositionState.() -> Unit = {}
-): CameraPositionState = rememberSaveable(key = key, saver = CameraPositionState.Saver) {
-    CameraPositionState().apply(init)
 }


### PR DESCRIPTION
The camera position is now saved even when the device orientation changes. Also it removes the need for the `neverEqualPolicy()`, which was a bit of a hack before :innocent:.

Before this fix, we can see that changing the device orientation resets the camera position (arguably difficult to see on those videos, but it's obvious when actually holding the devices :grin:):

https://github.com/ramani-maps/ramani-maps/assets/2606672/b0f8c10c-6098-4073-8082-e09d362d0c2b

After the fix, the camera position is saved across lifecycle changes:


https://github.com/ramani-maps/ramani-maps/assets/2606672/4844f803-a6d6-4c68-9b17-0bb9b1b7771b

