### PR TITLE
maplibre: update android-plugin-annotation-v9 to 2.0.2

### DIFF
--- a/ramani-maplibre/build.gradle
+++ b/ramani-maplibre/build.gradle
@@ -92,7 +92,7 @@ allprojects {
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1'
 
         api 'org.maplibre.gl:android-sdk:10.2.0'
-        api 'org.maplibre.gl:android-plugin-annotation-v9:2.0.1'
+        api 'org.maplibre.gl:android-plugin-annotation-v9:2.0.2'
 
         testImplementation 'junit:junit:4.13.2'
     }


### PR DESCRIPTION
This brings [one minor fix of 2.0.2](https://github.com/maplibre/maplibre-plugins-android/releases/tag/v2.0.2):

* Fix dragging ordering (see [corresponding issue](https://github.com/maplibre/maplibre-plugins-android/issues/44))