### PR TITLE
maplibre: expose camera motion animations (ease and fly)

### DIFF
--- a/ramani-maplibre/build.gradle
+++ b/ramani-maplibre/build.gradle
@@ -30,6 +30,7 @@ allprojects {
     apply plugin: 'com.android.library'
     apply plugin: 'kotlin-android'
     apply plugin: 'kotlin-kapt'
+    apply plugin: 'kotlin-parcelize'
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/CameraPositionState.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/CameraPositionState.kt
@@ -10,48 +10,37 @@
 
 package org.ramani.compose
 
-import android.os.Parcel
 import android.os.Parcelable
 import com.mapbox.mapboxsdk.geometry.LatLng
+import kotlinx.parcelize.Parcelize
+import org.ramani.compose.CameraMotionType.EASE
+import org.ramani.compose.CameraMotionType.FLY
+import org.ramani.compose.CameraMotionType.INSTANT
 
+/**
+ * @property INSTANT Move the camera instantaneously to the new position.
+ * @property EASE Gradually move the camera over [CameraPosition.animationDurationMs] milliseconds.
+ * @property FLY Move the camera using a transition that evokes a powered flight
+ *           over [CameraPosition.animationDurationMs] milliseconds.
+ */
+@Parcelize
+enum class CameraMotionType : Parcelable { INSTANT, EASE, FLY }
+
+@Parcelize
 data class CameraPosition(
     var target: LatLng? = null,
     var zoom: Double? = null,
     var tilt: Double? = null,
     var bearing: Double? = null,
+    var motionType: CameraMotionType = FLY,
+    var animationDurationMs: Int = 1000,
 ) : Parcelable {
     constructor(cameraPosition: CameraPosition) : this(
         cameraPosition.target,
         cameraPosition.zoom,
         cameraPosition.tilt,
-        cameraPosition.bearing
+        cameraPosition.bearing,
+        cameraPosition.motionType,
+        cameraPosition.animationDurationMs,
     )
-
-    constructor(parcel: Parcel) : this(
-        parcel.readParcelable(LatLng::class.java.classLoader),
-        parcel.readValue(Double::class.java.classLoader) as? Double,
-        parcel.readValue(Double::class.java.classLoader) as? Double,
-        parcel.readValue(Double::class.java.classLoader) as? Double
-    )
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeParcelable(target, flags)
-        parcel.writeValue(zoom)
-        parcel.writeValue(tilt)
-        parcel.writeValue(bearing)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    companion object CREATOR : Parcelable.Creator<CameraPosition> {
-        override fun createFromParcel(parcel: Parcel): CameraPosition {
-            return CameraPosition(parcel)
-        }
-
-        override fun newArray(size: Int): Array<CameraPosition?> {
-            return arrayOfNulls(size)
-        }
-    }
 }

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -35,6 +35,7 @@ import com.mapbox.android.gestures.MoveGestureDetector
 import com.mapbox.android.gestures.RotateGestureDetector
 import com.mapbox.android.gestures.ShoveGestureDetector
 import com.mapbox.android.gestures.StandardScaleGestureDetector
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
 import com.mapbox.mapboxsdk.location.LocationComponentOptions
 import com.mapbox.mapboxsdk.location.engine.LocationEngineCallback
@@ -294,7 +295,21 @@ internal fun MapUpdater(cameraPosition: CameraPosition) {
 
         update(cameraPosition) {
             this.cameraPosition = it
-            map.cameraPosition = cameraPosition.toMapbox()
+            val cameraUpdate = CameraUpdateFactory.newCameraPosition(cameraPosition.toMapbox())
+
+            when (cameraPosition.motionType) {
+                CameraMotionType.INSTANT -> map.moveCamera(cameraUpdate)
+
+                CameraMotionType.EASE -> map.easeCamera(
+                    cameraUpdate,
+                    cameraPosition.animationDurationMs
+                )
+
+                CameraMotionType.FLY -> map.animateCamera(
+                    cameraUpdate,
+                    cameraPosition.animationDurationMs
+                )
+            }
         }
     })
 }


### PR DESCRIPTION
Expose the different camera motion animations:

* INSTANT just "teleports" the camera to the new position (that was the behaviour until now).
* EASE gradually moves the camera over some duration (defined with `animationDurationMs`).
* FLY moves the camera with a transition that evokes a powered flight over some duration (defined with `animationDurationMs`).

At the same time I discovered the `kotlin-parcelize` plugin which makes it easier to implement `Parcelable`.