### PR TITLE
Refactor parcelize boilerplate

### DIFF
--- a/ramani-maplibre/src/main/java/org/ramani/compose/CameraPositionState.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/CameraPositionState.kt
@@ -27,7 +27,7 @@ import org.ramani.compose.CameraMotionType.INSTANT
 enum class CameraMotionType : Parcelable { INSTANT, EASE, FLY }
 
 @Parcelize
-data class CameraPosition(
+class CameraPosition(
     var target: LatLng? = null,
     var zoom: Double? = null,
     var tilt: Double? = null,
@@ -43,4 +43,28 @@ data class CameraPosition(
         cameraPosition.motionType,
         cameraPosition.animationDurationMs,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as CameraPosition
+
+        if (target != other.target) return false
+        if (zoom != other.zoom) return false
+        if (tilt != other.tilt) return false
+        if (bearing != other.bearing) return false
+        if (motionType != other.motionType) return false
+        return animationDurationMs == other.animationDurationMs
+    }
+
+    override fun hashCode(): Int {
+        var result = target?.hashCode() ?: 0
+        result = 31 * result + (zoom?.hashCode() ?: 0)
+        result = 31 * result + (tilt?.hashCode() ?: 0)
+        result = 31 * result + (bearing?.hashCode() ?: 0)
+        result = 31 * result + motionType.hashCode()
+        result = 31 * result + animationDurationMs
+        return result
+    }
 }

--- a/ramani-maplibre/src/main/java/org/ramani/compose/LocationRequestProperties.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/LocationRequestProperties.kt
@@ -9,8 +9,8 @@
  */
 package org.ramani.compose
 
-import android.os.Parcel
 import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import org.ramani.compose.LocationPriority.PRIORITY_BALANCED_POWER_ACCURACY
 import org.ramani.compose.LocationPriority.PRIORITY_HIGH_ACCURACY
 import org.ramani.compose.LocationPriority.PRIORITY_LOW_POWER
@@ -22,13 +22,15 @@ import org.ramani.compose.LocationPriority.PRIORITY_NO_POWER
  * @property PRIORITY_LOW_POWER Request coarse ~10km accuracy location.
  * @property PRIORITY_NO_POWER Request passive location (no locations will be returned unless a different client requests location updates).
  */
-enum class LocationPriority(val value: Int) {
+@Parcelize
+enum class LocationPriority(val value: Int) : Parcelable {
     PRIORITY_HIGH_ACCURACY(0),
     PRIORITY_BALANCED_POWER_ACCURACY(1),
     PRIORITY_LOW_POWER(2),
     PRIORITY_NO_POWER(3)
 }
 
+@Parcelize
 class LocationRequestProperties(
     var priority: LocationPriority = PRIORITY_HIGH_ACCURACY,
     var interval: Long = 1000L,
@@ -43,26 +45,6 @@ class LocationRequestProperties(
         locationRequestProperties.displacement,
         locationRequestProperties.maxWaitTime,
     )
-
-    constructor(parcel: Parcel) : this(
-        LocationPriority.valueOf(parcel.readInt().toString()),
-        parcel.readLong(),
-        parcel.readLong(),
-        parcel.readFloat(),
-        parcel.readLong()
-    )
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeInt(priority.value)
-        parcel.writeLong(interval)
-        parcel.writeLong(fastestInterval)
-        parcel.writeFloat(displacement)
-        parcel.writeLong(maxWaitTime)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -84,15 +66,5 @@ class LocationRequestProperties(
         result = 31 * result + displacement.hashCode()
         result = 31 * result + maxWaitTime.hashCode()
         return result
-    }
-
-    companion object CREATOR : Parcelable.Creator<LocationRequestProperties> {
-        override fun createFromParcel(parcel: Parcel): LocationRequestProperties {
-            return LocationRequestProperties(parcel)
-        }
-
-        override fun newArray(size: Int): Array<LocationRequestProperties?> {
-            return arrayOfNulls(size)
-        }
     }
 }

--- a/ramani-maplibre/src/main/java/org/ramani/compose/LocationStyling.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/LocationStyling.kt
@@ -9,9 +9,9 @@
  */
 package org.ramani.compose
 
-import android.os.Parcel
 import android.os.Parcelable
 import androidx.annotation.ColorInt
+import kotlinx.parcelize.Parcelize
 
 /**
  * @property accuracyAlpha Opacity of the accuracy view between 0 (transparent) and 1 (opaque).
@@ -20,6 +20,7 @@ import androidx.annotation.ColorInt
  * @property enablePulseFade Enable the fading of the pulsing circle.
  * @property pulseColor Color of the pulsing circle.
  */
+@Parcelize
 class LocationStyling(
     var accuracyAlpha: Float? = null,
     @ColorInt var accuracyColor: Int? = null,
@@ -34,26 +35,6 @@ class LocationStyling(
         locationStyling.enablePulseFade,
         locationStyling.pulseColor,
     )
-
-    constructor(parcel: Parcel) : this(
-        parcel.readValue(Float::class.java.classLoader) as? Float,
-        parcel.readValue(Int::class.java.classLoader) as? Int,
-        parcel.readValue(Boolean::class.java.classLoader) as? Boolean,
-        parcel.readValue(Boolean::class.java.classLoader) as? Boolean,
-        parcel.readValue(Int::class.java.classLoader) as? Int
-    )
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeValue(accuracyAlpha)
-        parcel.writeValue(accuracyColor)
-        parcel.writeValue(enablePulse)
-        parcel.writeValue(enablePulseFade)
-        parcel.writeValue(pulseColor)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -75,15 +56,5 @@ class LocationStyling(
         result = 31 * result + (enablePulseFade?.hashCode() ?: 0)
         result = 31 * result + (pulseColor ?: 0)
         return result
-    }
-
-    companion object CREATOR : Parcelable.Creator<LocationStyling> {
-        override fun createFromParcel(parcel: Parcel): LocationStyling {
-            return LocationStyling(parcel)
-        }
-
-        override fun newArray(size: Int): Array<LocationStyling?> {
-            return arrayOfNulls(size)
-        }
     }
 }

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapProperties.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapProperties.kt
@@ -9,11 +9,12 @@
  */
 package org.ramani.compose
 
-import android.os.Parcel
 import android.os.Parcelable
 import androidx.annotation.FloatRange
 import com.mapbox.mapboxsdk.constants.MapboxConstants
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 class MapProperties(
     @FloatRange(
         from = MapboxConstants.MINIMUM_ZOOM.toDouble(),
@@ -21,16 +22,6 @@ class MapProperties(
     ) var maxZoom: Double? = null,
 ) : Parcelable {
     constructor(mapProperties: MapProperties) : this(mapProperties.maxZoom)
-
-    constructor(parcel: Parcel) : this(parcel.readValue(Double::class.java.classLoader) as? Double)
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeValue(maxZoom)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -43,15 +34,5 @@ class MapProperties(
 
     override fun hashCode(): Int {
         return maxZoom?.hashCode() ?: 0
-    }
-
-    companion object CREATOR : Parcelable.Creator<MapProperties> {
-        override fun createFromParcel(parcel: Parcel): MapProperties {
-            return MapProperties(parcel)
-        }
-
-        override fun newArray(size: Int): Array<MapProperties?> {
-            return arrayOfNulls(size)
-        }
     }
 }

--- a/ramani-maplibre/src/main/java/org/ramani/compose/UiSettings.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/UiSettings.kt
@@ -11,19 +11,11 @@ package org.ramani.compose
 
 import android.os.Parcel
 import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 class UiSettings(var compassMargins: CompassMargins = CompassMargins()) : Parcelable {
     constructor(uiSettings: UiSettings) : this(uiSettings.compassMargins)
-
-    constructor(parcel: Parcel) : this(parcel.readParcelable<CompassMargins>(CompassMargins::class.java.classLoader)!!)
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeParcelable(compassMargins, flags)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -37,18 +29,9 @@ class UiSettings(var compassMargins: CompassMargins = CompassMargins()) : Parcel
     override fun hashCode(): Int {
         return compassMargins.hashCode()
     }
-
-    companion object CREATOR : Parcelable.Creator<UiSettings> {
-        override fun createFromParcel(parcel: Parcel): UiSettings {
-            return UiSettings(parcel)
-        }
-
-        override fun newArray(size: Int): Array<UiSettings?> {
-            return arrayOfNulls(size)
-        }
-    }
 }
 
+@Parcelize
 class CompassMargins(val left: Int = 0, val top: Int = 0, val right: Int = 0, val bottom: Int = 0) :
     Parcelable {
     constructor(parcel: Parcel) : this(
@@ -57,17 +40,6 @@ class CompassMargins(val left: Int = 0, val top: Int = 0, val right: Int = 0, va
         parcel.readInt(),
         parcel.readInt()
     )
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeInt(left)
-        parcel.writeInt(top)
-        parcel.writeInt(right)
-        parcel.writeInt(bottom)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -87,15 +59,5 @@ class CompassMargins(val left: Int = 0, val top: Int = 0, val right: Int = 0, va
         result = 31 * result + right
         result = 31 * result + bottom
         return result
-    }
-
-    companion object CREATOR : Parcelable.Creator<CompassMargins> {
-        override fun createFromParcel(parcel: Parcel): CompassMargins {
-            return CompassMargins(parcel)
-        }
-
-        override fun newArray(size: Int): Array<CompassMargins?> {
-            return arrayOfNulls(size)
-        }
     }
 }


### PR DESCRIPTION
I just discovered the gradle plugin "kotlin-parcelize" which is official (i.e. by JetBrains) and removes a lot of Parcelable boilerplate \o/: https://developer.android.com/kotlin/parcelize.

At the same time I removed the `data class CameraPosition` and made it a `class CameraPosition`, because I also learned that data classes are not ABI stable: https://kotlinlang.org/docs/jvm-api-guidelines-backward-compatibility.html#don-t-use-data-classes-in-an-api.