### PR TITLE
Updated Maplibre to v11.0.0

### DIFF
--- a/examples/clusters/app/src/main/java/org/ramani/example/clusters/MainActivity.kt
+++ b/examples/clusters/app/src/main/java/org/ramani/example/clusters/MainActivity.kt
@@ -8,13 +8,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.style.expressions.Expression
-import com.mapbox.mapboxsdk.style.layers.CircleLayer
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory
-import com.mapbox.mapboxsdk.style.layers.SymbolLayer
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import org.maplibre.android.MapLibre
+import org.maplibre.android.style.expressions.Expression
+import org.maplibre.android.style.layers.CircleLayer
+import org.maplibre.android.style.layers.PropertyFactory
+import org.maplibre.android.style.layers.SymbolLayer
+import org.maplibre.android.style.sources.GeoJsonOptions
+import org.maplibre.android.style.sources.GeoJsonSource
 import org.ramani.compose.MapLibre
 import org.ramani.example.clusters.ui.theme.ClustersTheme
 import java.net.URI
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
 
         // This is usually done in the MapLibre composable, but in this case we need to initialize
         // the map earlier in order to define the sources and layers.
-        Mapbox.getInstance(this)
+        MapLibre.getInstance(this)
 
         // Define the source GeoJson.
         val mySource = GeoJsonSource(

--- a/examples/custom-layers/app/src/main/java/org/ramani/example/custom_layers/MainActivity.kt
+++ b/examples/custom-layers/app/src/main/java/org/ramani/example/custom_layers/MainActivity.kt
@@ -8,15 +8,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.style.expressions.Expression
-import com.mapbox.mapboxsdk.style.layers.FillLayer
-import com.mapbox.mapboxsdk.style.layers.LineLayer
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory
-import com.mapbox.mapboxsdk.style.layers.RasterLayer
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
-import com.mapbox.mapboxsdk.style.sources.RasterSource
-import com.mapbox.mapboxsdk.style.sources.VectorSource
+import org.maplibre.android.MapLibre
+import org.maplibre.android.style.expressions.Expression
+import org.maplibre.android.style.layers.FillLayer
+import org.maplibre.android.style.layers.LineLayer
+import org.maplibre.android.style.layers.PropertyFactory
+import org.maplibre.android.style.layers.RasterLayer
+import org.maplibre.android.style.sources.GeoJsonSource
+import org.maplibre.android.style.sources.RasterSource
+import org.maplibre.android.style.sources.VectorSource
 import org.ramani.compose.MapLibre
 import org.ramani.example.custom_layers.ui.theme.CustomLayersTheme
 import java.net.URI
@@ -27,7 +27,7 @@ class MainActivity : ComponentActivity() {
 
         // This is usually done in the MapLibre composable, but in this case we need to initialize
         // the map earlier in order to define the sources and layers.
-        Mapbox.getInstance(this)
+        MapLibre.getInstance(this)
 
         // Define the source GeoJson:
         //    "Geographical UAS zones of Switzerland"

--- a/examples/interactive-polygon/app/src/main/java/org/ramani/example/interactive_polygon/MainActivity.kt
+++ b/examples/interactive-polygon/app/src/main/java/org/ramani/example/interactive_polygon/MainActivity.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 import org.ramani.compose.CameraPosition
 import org.ramani.compose.Circle
 import org.ramani.compose.MapLibre

--- a/examples/location/app/src/main/java/org/ramani/example/location/MainActivity.kt
+++ b/examples/location/app/src/main/java/org/ramani/example/location/MainActivity.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 import org.ramani.compose.CameraPosition
 import org.ramani.compose.LocationRequestProperties
 import org.ramani.compose.LocationStyling

--- a/ramani-maplibre/build.gradle
+++ b/ramani-maplibre/build.gradle
@@ -87,12 +87,12 @@ allprojects {
         implementation "androidx.compose.foundation:foundation:$compose_ui_version"
         implementation "androidx.compose.material:material:$compose_ui_version"
         implementation "androidx.compose.ui:ui:$compose_ui_version"
-        implementation 'androidx.core:core-ktx:1.12.0'
+        implementation 'androidx.core:core-ktx:1.13.1'
         implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-        implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1'
+        implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
-        api 'org.maplibre.gl:android-sdk:10.2.0'
-        api 'org.maplibre.gl:android-plugin-annotation-v9:2.0.2'
+        api 'org.maplibre.gl:android-sdk:11.0.0'
+        api 'org.maplibre.gl:android-plugin-annotation-v9:3.0.0'
 
         testImplementation 'junit:junit:4.13.2'
     }

--- a/ramani-maplibre/src/main/java/org/ramani/compose/CameraPositionState.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/CameraPositionState.kt
@@ -11,7 +11,7 @@
 package org.ramani.compose
 
 import android.os.Parcelable
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 import kotlinx.parcelize.Parcelize
 import org.ramani.compose.CameraMotionType.EASE
 import org.ramani.compose.CameraMotionType.FLY

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Circle.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Circle.kt
@@ -13,8 +13,8 @@ package org.ramani.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.plugins.annotation.CircleOptions
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.plugins.annotation.CircleOptions
 
 @Composable
 @MapLibreComposable

--- a/ramani-maplibre/src/main/java/org/ramani/compose/CircleWithItem.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/CircleWithItem.kt
@@ -13,7 +13,7 @@ package org.ramani.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 
 @Composable
 fun UpdateCenter(coord: LatLng, centerUpdated: (LatLng) -> Unit) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/CoordToPixelMapper.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/CoordToPixelMapper.kt
@@ -13,7 +13,7 @@ package org.ramani.compose
 import android.graphics.PointF
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 
 @Composable
 fun CoordToPixelMapper(coordinates: MutableList<LatLng>, onChange: (List<PointF>) -> Unit) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/DistanceBetweenCoords.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/DistanceBetweenCoords.kt
@@ -13,7 +13,7 @@ package org.ramani.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
 import androidx.core.graphics.minus
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 
 @MapLibreComposable
 @Composable

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Fill.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Fill.kt
@@ -13,8 +13,8 @@ package org.ramani.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.plugins.annotation.FillOptions
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.plugins.annotation.FillOptions
 
 @Composable
 @MapLibreComposable

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -35,23 +35,23 @@ import com.mapbox.android.gestures.MoveGestureDetector
 import com.mapbox.android.gestures.RotateGestureDetector
 import com.mapbox.android.gestures.ShoveGestureDetector
 import com.mapbox.android.gestures.StandardScaleGestureDetector
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
-import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
-import com.mapbox.mapboxsdk.location.LocationComponentOptions
-import com.mapbox.mapboxsdk.location.engine.LocationEngineCallback
-import com.mapbox.mapboxsdk.location.engine.LocationEngineDefault
-import com.mapbox.mapboxsdk.location.engine.LocationEngineRequest
-import com.mapbox.mapboxsdk.location.engine.LocationEngineResult
-import com.mapbox.mapboxsdk.location.modes.RenderMode
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnMoveListener
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnRotateListener
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnScaleListener
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnShoveListener
-import com.mapbox.mapboxsdk.maps.Style
-import com.mapbox.mapboxsdk.style.layers.Layer
-import com.mapbox.mapboxsdk.style.sources.Source
-import com.mapbox.mapboxsdk.utils.BitmapUtils
+import org.maplibre.android.camera.CameraUpdateFactory
+import org.maplibre.android.location.LocationComponentActivationOptions
+import org.maplibre.android.location.LocationComponentOptions
+import org.maplibre.android.location.engine.LocationEngineCallback
+import org.maplibre.android.location.engine.LocationEngineDefault
+import org.maplibre.android.location.engine.LocationEngineRequest
+import org.maplibre.android.location.engine.LocationEngineResult
+import org.maplibre.android.location.modes.RenderMode
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapLibreMap.OnMoveListener
+import org.maplibre.android.maps.MapLibreMap.OnRotateListener
+import org.maplibre.android.maps.MapLibreMap.OnScaleListener
+import org.maplibre.android.maps.MapLibreMap.OnShoveListener
+import org.maplibre.android.maps.Style
+import org.maplibre.android.style.layers.Layer
+import org.maplibre.android.style.sources.Source
+import org.maplibre.android.utils.BitmapUtils
 
 @Retention(AnnotationRetention.BINARY)
 @ComposableTargetMarker(description = "Maplibre Composable")
@@ -153,7 +153,7 @@ fun MapLibre(
     }
 }
 
-private fun MapboxMap.applyUiSettings(uiSettings: UiSettings) {
+private fun MapLibreMap.applyUiSettings(uiSettings: UiSettings) {
     this.uiSettings.setCompassMargins(
         uiSettings.compassMargins.left,
         uiSettings.compassMargins.top,
@@ -162,11 +162,11 @@ private fun MapboxMap.applyUiSettings(uiSettings: UiSettings) {
     )
 }
 
-private fun MapboxMap.applyProperties(properties: MapProperties) {
+private fun MapLibreMap.applyProperties(properties: MapProperties) {
     properties.maxZoom?.let { this.setMaxZoomPreference(it) }
 }
 
-private fun MapboxMap.setupLocation(
+private fun MapLibreMap.setupLocation(
     context: Context,
     style: Style,
     locationRequestProperties: LocationRequestProperties?,
@@ -246,7 +246,7 @@ private fun LocationRequestProperties.toMapLibre(): LocationEngineRequest {
         .build()
 }
 
-private fun MapboxMap.addImages(context: Context, images: List<Pair<String, Int>>?) {
+private fun MapLibreMap.addImages(context: Context, images: List<Pair<String, Int>>?) {
     images?.let {
         images.mapNotNull { image ->
             val drawable = context.getDrawable(image.second)
@@ -258,11 +258,11 @@ private fun MapboxMap.addImages(context: Context, images: List<Pair<String, Int>
     }
 }
 
-private fun MapboxMap.addSources(sources: List<Source>?) {
+private fun MapLibreMap.addSources(sources: List<Source>?) {
     sources?.let { sources.forEach { style!!.addSource(it) } }
 }
 
-private fun MapboxMap.addLayers(layers: List<Layer>?) {
+private fun MapLibreMap.addLayers(layers: List<Layer>?) {
     layers?.let { layers.forEach { style!!.addLayer(it) } }
 }
 
@@ -338,7 +338,7 @@ internal fun MapUpdater(cameraPosition: CameraPosition) {
 
         update(cameraPosition) {
             this.cameraPosition = it
-            val cameraUpdate = CameraUpdateFactory.newCameraPosition(cameraPosition.toMapbox())
+            val cameraUpdate = CameraUpdateFactory.newCameraPosition(cameraPosition.toMapLibre())
 
             when (cameraPosition.motionType) {
                 CameraMotionType.INSTANT -> map.moveCamera(cameraUpdate)
@@ -358,16 +358,16 @@ internal fun MapUpdater(cameraPosition: CameraPosition) {
 }
 
 internal class MapPropertiesNode(
-    val map: MapboxMap,
+    val map: MapLibreMap,
     var cameraPosition: CameraPosition
 ) : MapNode {
     override fun onAttached() {
-        map.cameraPosition = cameraPosition.toMapbox()
+        map.cameraPosition = cameraPosition.toMapLibre()
     }
 }
 
-internal fun CameraPosition.toMapbox(): com.mapbox.mapboxsdk.camera.CameraPosition {
-    val builder = com.mapbox.mapboxsdk.camera.CameraPosition.Builder()
+internal fun CameraPosition.toMapLibre(): org.maplibre.android.camera.CameraPosition {
+    val builder = org.maplibre.android.camera.CameraPosition.Builder()
 
     target?.let { builder.target(it) }
     zoom?.let { builder.zoom(it) }

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
@@ -17,22 +17,22 @@ import androidx.compose.runtime.CompositionContext
 import com.mapbox.android.gestures.MoveGestureDetector
 import com.mapbox.android.gestures.RotateGestureDetector
 import com.mapbox.android.gestures.StandardScaleGestureDetector
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnMoveListener
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnRotateListener
-import com.mapbox.mapboxsdk.maps.MapboxMap.OnScaleListener
-import com.mapbox.mapboxsdk.maps.Style
-import com.mapbox.mapboxsdk.plugins.annotation.AnnotationManager
-import com.mapbox.mapboxsdk.plugins.annotation.Circle
-import com.mapbox.mapboxsdk.plugins.annotation.CircleManager
-import com.mapbox.mapboxsdk.plugins.annotation.Fill
-import com.mapbox.mapboxsdk.plugins.annotation.FillManager
-import com.mapbox.mapboxsdk.plugins.annotation.Line
-import com.mapbox.mapboxsdk.plugins.annotation.LineManager
-import com.mapbox.mapboxsdk.plugins.annotation.OnCircleDragListener
-import com.mapbox.mapboxsdk.plugins.annotation.Symbol
-import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapLibreMap.OnMoveListener
+import org.maplibre.android.maps.MapLibreMap.OnRotateListener
+import org.maplibre.android.maps.MapLibreMap.OnScaleListener
+import org.maplibre.android.maps.Style
+import org.maplibre.android.plugins.annotation.AnnotationManager
+import org.maplibre.android.plugins.annotation.Circle
+import org.maplibre.android.plugins.annotation.CircleManager
+import org.maplibre.android.plugins.annotation.Fill
+import org.maplibre.android.plugins.annotation.FillManager
+import org.maplibre.android.plugins.annotation.Line
+import org.maplibre.android.plugins.annotation.LineManager
+import org.maplibre.android.plugins.annotation.OnCircleDragListener
+import org.maplibre.android.plugins.annotation.Symbol
+import org.maplibre.android.plugins.annotation.SymbolManager
 import kotlinx.coroutines.awaitCancellation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -60,7 +60,7 @@ internal suspend fun MapView.newComposition(
     }
 }
 
-internal suspend fun MapboxMap.awaitStyle(styleUrl: String) = suspendCoroutine { continuation ->
+internal suspend fun MapLibreMap.awaitStyle(styleUrl: String) = suspendCoroutine { continuation ->
     setStyle(styleUrl) { style ->
         continuation.resume(style)
     }
@@ -75,7 +75,7 @@ internal interface MapNode {
 private object MapNodeRoot : MapNode
 
 internal class MapApplier(
-    val map: MapboxMap,
+    val map: MapLibreMap,
     val mapView: MapView,
     val style: Style
 ) : AbstractApplier<MapNode>(MapNodeRoot) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapProperties.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapProperties.kt
@@ -11,14 +11,14 @@ package org.ramani.compose
 
 import android.os.Parcelable
 import androidx.annotation.FloatRange
-import com.mapbox.mapboxsdk.constants.MapboxConstants
+import org.maplibre.android.constants.MapLibreConstants
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 class MapProperties(
     @FloatRange(
-        from = MapboxConstants.MINIMUM_ZOOM.toDouble(),
-        to = MapboxConstants.MAXIMUM_ZOOM.toDouble()
+        from = MapLibreConstants.MINIMUM_ZOOM.toDouble(),
+        to = MapLibreConstants.MAXIMUM_ZOOM.toDouble()
     ) var maxZoom: Double? = null,
 ) : Parcelable {
     constructor(mapProperties: MapProperties) : this(mapProperties.maxZoom)

--- a/ramani-maplibre/src/main/java/org/ramani/compose/PixelToCoordMapper.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/PixelToCoordMapper.kt
@@ -13,7 +13,7 @@ package org.ramani.compose
 import android.graphics.PointF
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 
 @Composable
 fun PixelToCoordMapper(points: List<PointF>, onChange: (List<LatLng>) -> Unit) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Polygon.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Polygon.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.core.graphics.minus
 import androidx.core.graphics.plus
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 import kotlin.math.atan2
 
 @Composable

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
@@ -13,8 +13,8 @@ package org.ramani.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.currentComposer
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.plugins.annotation.LineOptions
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.plugins.annotation.LineOptions
 
 @Composable
 @MapLibreComposable

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
@@ -16,10 +16,10 @@ import androidx.compose.runtime.currentComposer
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.res.imageResource
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions
-import com.mapbox.mapboxsdk.style.layers.Property.TEXT_ANCHOR_CENTER
-import com.mapbox.mapboxsdk.style.layers.Property.TEXT_JUSTIFY_CENTER
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.plugins.annotation.SymbolOptions
+import org.maplibre.android.style.layers.Property.TEXT_ANCHOR_CENTER
+import org.maplibre.android.style.layers.Property.TEXT_JUSTIFY_CENTER
 
 @Composable
 @MapLibreComposable

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Utils.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Utils.kt
@@ -18,16 +18,16 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
+import org.maplibre.android.MapLibre
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.MapLibreMap
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 @Composable
 fun rememberMapViewWithLifecycle(): MapView {
     val context = LocalContext.current
-    Mapbox.getInstance(context)
+    MapLibre.getInstance(context)
     val mapView = remember { MapView(context) }
     val lifecycle = LocalLifecycleOwner.current.lifecycle
 
@@ -57,7 +57,7 @@ fun getMapLifecycleObserver(mapView: MapView): LifecycleEventObserver {
     }
 }
 
-suspend inline fun MapView.awaitMap(): MapboxMap =
+suspend inline fun MapView.awaitMap(): MapLibreMap =
     suspendCoroutine { continuation ->
         getMapAsync {
             continuation.resume(it)

--- a/ramani-maplibre/src/main/java/org/ramani/compose/VertexInsertCalculator.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/VertexInsertCalculator.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
 import androidx.core.graphics.minus
 import androidx.core.graphics.plus
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
 
 @MapLibreComposable
 @Composable


### PR DESCRIPTION
Updated Maplibre to v11.0.0, which includes the fix for #66, and refactored the imports.

Tested successfully with the location and the interactive-polygon examples (at the moment, they use a composite instead of a direct implementation).

Resolves #66.