### PR TITLE
feat(styleUrl): add support for dynamic styleUrls

### DIFF
--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -346,8 +346,7 @@ internal fun MapUpdater(cameraPosition: CameraPosition, styleUrl: String) {
         observeIdle(cameraPosition)
 
         update(styleUrl) {
-            this.styleUrl = it
-            updateStyle()
+            updateStyle(it)
         }
 
         update(cameraPosition) {
@@ -374,14 +373,15 @@ internal fun MapUpdater(cameraPosition: CameraPosition, styleUrl: String) {
 internal class MapPropertiesNode(
     val map: MapLibreMap,
     var cameraPosition: CameraPosition,
-    var styleUrl: String
+    var styleUrl: String,
 ) : MapNode {
     override fun onAttached() {
         map.cameraPosition = cameraPosition.toMapLibre()
     }
 
-    fun updateStyle() {
+    fun updateStyle(styleUrl: String) {
         map.setStyle(styleUrl)
+        this.styleUrl = styleUrl
     }
 }
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -124,7 +124,6 @@ fun MapLibre(
 
     AndroidView(modifier = modifier, factory = { map })
     LaunchedEffect(
-        currentStyleUrl,
         currentUiSettings,
         currentMapProperties,
         currentLocationRequestProperties,
@@ -160,6 +159,11 @@ fun MapLibre(
                 }
             }
         }
+    }
+
+    LaunchedEffect(currentStyleUrl) {
+        val maplibreMap = map.awaitMap()
+        maplibreMap.setStyle(currentStyleUrl)
     }
 }
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -119,10 +119,12 @@ fun MapLibre(
     val currentLayers by rememberUpdatedState(layers)
     val currentImages by rememberUpdatedState(images)
     val currentContent by rememberUpdatedState(content)
+    val currentStyleUrl by rememberUpdatedState(styleUrl)
     val parentComposition = rememberCompositionContext()
 
     AndroidView(modifier = modifier, factory = { map })
     LaunchedEffect(
+        currentStyleUrl,
         currentUiSettings,
         currentMapProperties,
         currentLocationRequestProperties,


### PR DESCRIPTION
Support dynamic style urls as described in https://github.com/ramani-maps/ramani-maps/issues/73

I could use some help deciding how best to optimize for performance since changing the `styleUrl` should not reload everything in this `LaunchedEffect` .. im just a little unsure how to create a separate effect that only calls `map.setStyle(styleUrl)`

Resolves #73 