### PR TITLE
Expose Style.Builder instead of a styleUrl string

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ class MainActivity : ComponentActivity() {
                     ) {
                         MapLibre(
                             modifier = Modifier.fillMaxSize(),
-                            styleUrl = "<Your style URL here>",
+                            styleBuilder = Style.Builder().fromUri("<Your style URL here>"),
                             cameraPosition = cameraPosition.value
                         ) {
                             // Create a handle for each vertex (those are blue circles)
@@ -177,7 +177,7 @@ class MainActivity : ComponentActivity() {
 
                     MapLibre(
                         modifier = Modifier.fillMaxSize(),
-                        styleUrl = "<Your style URL here>",
+                        styleBuilder = Style.Builder().fromUri("<Your style URL here>"),
                         cameraPosition = cameraPosition.value
                     ) {
                         // Create a draggable circle

--- a/examples/annotation-simple/app/src/main/java/org/ramani/example/annotation_simple/MainActivity.kt
+++ b/examples/annotation-simple/app/src/main/java/org/ramani/example/annotation_simple/MainActivity.kt
@@ -3,13 +3,18 @@ package org.ramani.example.annotation_simple
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.Style
 import org.ramani.compose.CameraPosition
 import org.ramani.compose.Circle
 import org.ramani.compose.MapLibre
@@ -17,6 +22,10 @@ import org.ramani.compose.Polyline
 import org.ramani.example.annotation_simple.ui.theme.AnnotationSimpleTheme
 
 class MainActivity : ComponentActivity() {
+    companion object {
+        const val DEFAULT_STYLE_URL = "https://demotiles.maplibre.org/style.json"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -31,24 +40,38 @@ class MainActivity : ComponentActivity() {
                     )
                 }
                 val circleCenter = rememberSaveable { mutableStateOf(LatLng(4.8, 46.0)) }
+                val isDefaultStyle = rememberSaveable { mutableStateOf(true) }
+                val styleUrl = rememberSaveable { mutableStateOf(DEFAULT_STYLE_URL) }
 
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    MapLibre(
+                Box {
+                    Surface(
                         modifier = Modifier.fillMaxSize(),
-                        styleUrl = resources.getString(R.string.maplibre_style_url),
-                        cameraPosition = cameraPosition.value,
+                        color = MaterialTheme.colorScheme.background
                     ) {
-                        Circle(
-                            center = circleCenter.value,
-                            radius = 50F,
-                            isDraggable = true,
-                            borderWidth = 2F,
-                            onCenterDragged = { center -> circleCenter.value = center }
-                        )
-                        Polyline(points = polylinePoints, color = "Red", lineWidth = 5.0F)
+                        MapLibre(
+                            modifier = Modifier.fillMaxSize(),
+                            styleBuilder = Style.Builder().fromUri(styleUrl.value),
+                            cameraPosition = cameraPosition.value,
+                        ) {
+                            Circle(
+                                center = circleCenter.value,
+                                radius = 50F,
+                                isDraggable = true,
+                                borderWidth = 2F,
+                                onCenterDragged = { center -> circleCenter.value = center }
+                            )
+                            Polyline(points = polylinePoints, color = "Red", lineWidth = 5.0F)
+                        }
+                    }
+                    Button(
+                        modifier = Modifier.align(Alignment.BottomCenter),
+                        onClick = {
+                            styleUrl.value =
+                                if (isDefaultStyle.value) DEFAULT_STYLE_URL
+                                else resources.getString(R.string.maplibre_style_url)
+                            isDefaultStyle.value = !isDefaultStyle.value
+                        }) {
+                        Text("Swap style")
                     }
                 }
             }

--- a/examples/custom-layers/app/src/main/java/org/ramani/example/custom_layers/MainActivity.kt
+++ b/examples/custom-layers/app/src/main/java/org/ramani/example/custom_layers/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import org.maplibre.android.MapLibre
+import org.maplibre.android.maps.Style
 import org.maplibre.android.style.expressions.Expression
 import org.maplibre.android.style.layers.FillLayer
 import org.maplibre.android.style.layers.LineLayer
@@ -106,7 +107,8 @@ class MainActivity : ComponentActivity() {
                 ) {
                     MapLibre(
                         modifier = Modifier.fillMaxSize(),
-                        styleUrl = resources.getString(R.string.maplibre_style_url),
+                        styleBuilder = Style.Builder()
+                            .fromUri(resources.getString(R.string.maplibre_style_url)),
                         sources = listOf(nfzSource, contourSource, hillShadeSource),
                         layers = listOf(nfzFill, nfzPoly, hillshadeLayer, contourLayer),
                     )

--- a/examples/interactive-polygon/app/src/main/java/org/ramani/example/interactive_polygon/MainActivity.kt
+++ b/examples/interactive-polygon/app/src/main/java/org/ramani/example/interactive_polygon/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.Style
 import org.ramani.compose.CameraPosition
 import org.ramani.compose.Circle
 import org.ramani.compose.MapLibre
@@ -40,7 +41,8 @@ class MainActivity : ComponentActivity() {
                     ) {
                         MapLibre(
                             modifier = Modifier.fillMaxSize(),
-                            styleUrl = resources.getString(R.string.maplibre_style_url),
+                            styleBuilder = Style.Builder()
+                                .fromUri(resources.getString(R.string.maplibre_style_url)),
                             cameraPosition = cameraPosition.value
                         ) {
                             polygonState.forEachIndexed { index, vertex ->

--- a/examples/location/app/src/main/java/org/ramani/example/location/MainActivity.kt
+++ b/examples/location/app/src/main/java/org/ramani/example/location/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.Style
 import org.ramani.compose.CameraPosition
 import org.ramani.compose.LocationRequestProperties
 import org.ramani.compose.LocationStyling
@@ -45,7 +46,8 @@ class MainActivity : ComponentActivity() {
                     ) {
                         MapLibre(
                             modifier = Modifier.fillMaxSize(),
-                            styleUrl = resources.getString(R.string.maplibre_style_url),
+                            styleBuilder = Style.Builder()
+                                .fromUri(resources.getString(R.string.maplibre_style_url)),
                             cameraPosition = cameraPosition.value,
                             locationRequestProperties = locationProperties.value,
                             locationStyling = LocationStyling(

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
@@ -14,10 +14,10 @@ import androidx.compose.runtime.AbstractApplier
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
+import kotlinx.coroutines.awaitCancellation
 import org.maplibre.android.gestures.MoveGestureDetector
 import org.maplibre.android.gestures.RotateGestureDetector
 import org.maplibre.android.gestures.StandardScaleGestureDetector
-import kotlinx.coroutines.awaitCancellation
 import org.maplibre.android.maps.MapLibreMap
 import org.maplibre.android.maps.MapLibreMap.OnMoveListener
 import org.maplibre.android.maps.MapLibreMap.OnRotateListener
@@ -60,11 +60,12 @@ internal suspend fun MapView.newComposition(
     }
 }
 
-internal suspend fun MapLibreMap.awaitStyle(styleUrl: String) = suspendCoroutine { continuation ->
-    setStyle(styleUrl) { style ->
-        continuation.resume(style)
+internal suspend fun MapLibreMap.awaitStyle(styleBuilder: Style.Builder) =
+    suspendCoroutine { continuation ->
+        setStyle(styleBuilder) { style ->
+            continuation.resume(style)
+        }
     }
-}
 
 interface MapNode {
     fun onAttached() {}


### PR DESCRIPTION
The `MapLibre` composable exposed a `styleUrl` until now. But this is limiting because users may want to get a `Style` from a JSON file instead of a URL to a JSON file.

This changes the interface of `MapLibre` such that it takes a `Style.Builder`. It is a breaking change, but it is trivial to adapt, e.g. from:

```
MapLibre(styleUrl = "path/to/style.json")
```

to

```
MapLibre(styleBuilder = Style.Builder().fromUri("path/to/style.json"))
```

Resolves #82.