### PR TITLE
Exposing more options for Polylines & Symbols

### DIFF
--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -101,6 +101,7 @@ fun MapLibre(
     layers: List<Layer>? = null,
     images: List<Pair<String, Int>>? = null,
     renderMode: Int = RenderMode.NORMAL,
+    onMapClick: (LatLng) -> Unit = {},
     onMapLongClick: (LatLng) -> Unit = {},
     content: (@Composable @MapLibreComposable () -> Unit)? = null,
 ) {
@@ -150,6 +151,11 @@ fun MapLibre(
 
             maplibreMap.addOnMapLongClickListener { latLng ->
                 onMapLongClick(latLng)
+                true
+            }
+
+            maplibreMap.addOnMapClickListener { latLng ->
+                onMapClick(latLng)
                 true
             }
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -103,6 +103,8 @@ fun MapLibre(
     renderMode: Int = RenderMode.NORMAL,
     onMapClick: (LatLng) -> Unit = {},
     onMapLongClick: (LatLng) -> Unit = {},
+    onMapMove: (MoveGestureDetector) -> Unit = {},
+    onMapZoom: (StandardScaleGestureDetector) -> Unit = {},
     content: (@Composable @MapLibreComposable () -> Unit)? = null,
 ) {
     if (LocalInspectionMode.current) {
@@ -149,15 +151,47 @@ fun MapLibre(
             maplibreMap.addSources(currentSources)
             maplibreMap.addLayers(currentLayers)
 
+            maplibreMap.addOnMapClickListener { latLng ->
+                onMapClick(latLng)
+                true
+            }
+            
             maplibreMap.addOnMapLongClickListener { latLng ->
                 onMapLongClick(latLng)
                 true
             }
 
-            maplibreMap.addOnMapClickListener { latLng ->
-                onMapClick(latLng)
-                true
-            }
+            maplibreMap.addOnMoveListener(
+                object : OnMoveListener {
+                    override fun onMoveBegin(detector: MoveGestureDetector) {
+                        onMapMove(detector)
+                    }
+
+                    override fun onMove(detector: MoveGestureDetector) {
+                        onMapMove(detector)
+                    }
+
+                    override fun onMoveEnd(detector: MoveGestureDetector) {
+                        onMapMove(detector)
+                    }
+                }
+            )
+
+            maplibreMap.addOnScaleListener(
+                object : OnScaleListener {
+                    override fun onScaleBegin(detector: StandardScaleGestureDetector) {
+                        onMapZoom(detector)
+                    }
+
+                    override fun onScale(detector: StandardScaleGestureDetector) {
+                        onMapZoom(detector)
+                    }
+
+                    override fun onScaleEnd(detector: StandardScaleGestureDetector) {
+                        onMapZoom(detector)
+                    }
+                }
+            )
 
             map.newComposition(parentComposition, style) {
                 CompositionLocalProvider {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -103,8 +103,6 @@ fun MapLibre(
     renderMode: Int = RenderMode.NORMAL,
     onMapClick: (LatLng) -> Unit = {},
     onMapLongClick: (LatLng) -> Unit = {},
-    onMapMove: (MoveGestureDetector) -> Unit = {},
-    onMapZoom: (StandardScaleGestureDetector) -> Unit = {},
     content: (@Composable @MapLibreComposable () -> Unit)? = null,
 ) {
     if (LocalInspectionMode.current) {
@@ -160,38 +158,6 @@ fun MapLibre(
                 onMapLongClick(latLng)
                 true
             }
-
-            maplibreMap.addOnMoveListener(
-                object : OnMoveListener {
-                    override fun onMoveBegin(detector: MoveGestureDetector) {
-                        onMapMove(detector)
-                    }
-
-                    override fun onMove(detector: MoveGestureDetector) {
-                        onMapMove(detector)
-                    }
-
-                    override fun onMoveEnd(detector: MoveGestureDetector) {
-                        onMapMove(detector)
-                    }
-                }
-            )
-
-            maplibreMap.addOnScaleListener(
-                object : OnScaleListener {
-                    override fun onScaleBegin(detector: StandardScaleGestureDetector) {
-                        onMapZoom(detector)
-                    }
-
-                    override fun onScale(detector: StandardScaleGestureDetector) {
-                        onMapZoom(detector)
-                    }
-
-                    override fun onScaleEnd(detector: StandardScaleGestureDetector) {
-                        onMapZoom(detector)
-                    }
-                }
-            )
 
             map.newComposition(parentComposition, style) {
                 CompositionLocalProvider {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
@@ -16,16 +16,6 @@ import androidx.compose.runtime.currentComposer
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.plugins.annotation.LineOptions
 
-enum class PolylineDashType(val dashArray: Array<Float>?) {
-    NoDash(null),
-    Dash(arrayOf(2f, 1f)),
-    LongDash(arrayOf(3f, 1f));
-    
-    companion object {
-        fun fromInt(value: Int) = entries.firstOrNull { it.ordinal == value } ?: NoDash
-    }
-}
-
 @Composable
 @MapLibreComposable
 fun Polyline(
@@ -34,7 +24,7 @@ fun Polyline(
     lineWidth: Float,
     zIndex: Int = 0,
     isDraggable: Boolean = false,
-    dashType: Array<Float>? = PolylineDashType.NoDash.dashArray,
+    dashType: Array<Float>? = null,
 ) {
     val mapApplier = currentComposer.applier as MapApplier
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
@@ -16,6 +16,16 @@ import androidx.compose.runtime.currentComposer
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.plugins.annotation.LineOptions
 
+enum class PolylineDashType(val dashArray: Array<Float>?) {
+    NoDash(null),
+    Dash(arrayOf(2f, 1f)),
+    LongDash(arrayOf(3f, 1f));
+    
+    companion object {
+        fun fromInt(value: Int) = entries.firstOrNull { it.ordinal == value } ?: SolidThickLine
+    }
+}
+
 @Composable
 @MapLibreComposable
 fun Polyline(
@@ -24,7 +34,7 @@ fun Polyline(
     lineWidth: Float,
     zIndex: Int = 0,
     isDraggable: Boolean = false,
-    isDashed: Boolean = false,
+    dashType: PolylineDashType,
 ) {
     val mapApplier = currentComposer.applier as MapApplier
 
@@ -36,9 +46,7 @@ fun Polyline(
             .withLineWidth(lineWidth)
             .withDraggable(isDraggable)
 
-        if (isDashed) {
-            lineManager.lineDasharray = arrayOf(1.0f, 4.0f)
-        }
+        lineManager.lineDasharray = dashType.dashArray
 
         val polyLine = lineManager.create(lineOptions)
         PolyLineNode(lineManager, polyLine)

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
@@ -34,7 +34,7 @@ fun Polyline(
     lineWidth: Float,
     zIndex: Int = 0,
     isDraggable: Boolean = false,
-    dashType: PolylineDashType,
+    dashType: Array<Float>? = PolylineDashType.NoDash.dashArray,
 ) {
     val mapApplier = currentComposer.applier as MapApplier
 
@@ -46,7 +46,7 @@ fun Polyline(
             .withLineWidth(lineWidth)
             .withDraggable(isDraggable)
 
-        lineManager.lineDasharray = dashType.dashArray
+        lineManager.lineDasharray = dashType
 
         val polyLine = lineManager.create(lineOptions)
         PolyLineNode(lineManager, polyLine)

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Polyline.kt
@@ -22,7 +22,7 @@ enum class PolylineDashType(val dashArray: Array<Float>?) {
     LongDash(arrayOf(3f, 1f));
     
     companion object {
-        fun fromInt(value: Int) = entries.firstOrNull { it.ordinal == value } ?: SolidThickLine
+        fun fromInt(value: Int) = entries.firstOrNull { it.ordinal == value } ?: NoDash
     }
 }
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
@@ -99,9 +99,7 @@ fun Symbol(
                         }
                     }
 
-                    override fun onAnnotationDragFinished(annotation: Symbol?) {
-
-                    }
+                    override fun onAnnotationDragFinished(annotation: Symbol?) {}
                 }
             )
         }

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.res.imageResource
 import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.plugins.annotation.OnSymbolDragListener
+import org.maplibre.android.plugins.annotation.Symbol
 import org.maplibre.android.plugins.annotation.SymbolOptions
 import org.maplibre.android.style.layers.Property.ICON_ANCHOR_CENTER
 import org.maplibre.android.style.layers.Property.TEXT_ANCHOR_CENTER
@@ -29,6 +31,7 @@ fun Symbol(
     size: Float,
     color: String,
     isDraggable: Boolean,
+    onDrag: (LatLng) -> Unit = {},
     zIndex: Int = 0,
     imageId: Int? = null,
     imageAnchor: String = ICON_ANCHOR_CENTER,
@@ -82,6 +85,29 @@ fun Symbol(
         }
 
         val symbol = symbolManager.create(symbolOptions)
+
+        if (isDraggable) {
+            symbolManager.addDragListener(
+                object: OnSymbolDragListener {
+                    override fun onAnnotationDragStarted(annotation: Symbol?) {
+                        
+                    }
+
+                    override fun onAnnotationDrag(annotation: Symbol?) {
+                        if (annotation == symbol) {
+                            annotation?.let {
+                                onDrag(it.latLng)
+                            }
+                        }
+                    }
+
+                    override fun onAnnotationDragFinished(annotation: Symbol?) {
+
+                    }
+                }
+            )
+        }
+
         SymbolNode(symbolManager, symbol)
     }, update = {
         set(center) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
@@ -90,7 +90,7 @@ fun Symbol(
             symbolManager.addDragListener(
                 object: OnSymbolDragListener {
                     override fun onAnnotationDragStarted(annotation: Symbol?) {
-                        
+
                     }
 
                     override fun onAnnotationDrag(annotation: Symbol?) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.res.imageResource
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.plugins.annotation.SymbolOptions
+import org.maplibre.android.style.layers.Property.ICON_ANCHOR_CENTER
 import org.maplibre.android.style.layers.Property.TEXT_ANCHOR_CENTER
 import org.maplibre.android.style.layers.Property.TEXT_JUSTIFY_CENTER
 
@@ -30,8 +31,16 @@ fun Symbol(
     isDraggable: Boolean,
     zIndex: Int = 0,
     imageId: Int? = null,
+    imageAnchor: String = ICON_ANCHOR_CENTER,
+    imageOffset: Array<Float> = arrayOf(0f, 0f),
     imageRotation: Float? = null,
-    text: String? = null
+    text: String? = null,
+    textAnchor: String = TEXT_ANCHOR_CENTER,
+    textJustify: String = TEXT_JUSTIFY_CENTER,
+    textOffset: Array<Float> = arrayOf(0f, 3f),
+    textColor: String = "#000000",
+    textHaloColor: String = "#000000",
+    textHaloWidth: Float = 0f
 ) {
     val mapApplier = currentComposer.applier as MapApplier
 
@@ -55,16 +64,21 @@ fun Symbol(
                 .withIconImage(imageId.toString())
                 .withIconColor(color)
                 .withIconSize(size)
+                .withIconAnchor(imageAnchor)
                 .withIconRotate(imageRotation)
+                .withIconOffset(imageOffset)
         }
 
         text?.let {
             symbolOptions = symbolOptions
                 .withTextField(text)
-                .withTextColor(color)
+                .withTextColor(textColor)
+                .withTextHaloColor(textHaloColor)
+                .withTextHaloWidth(textHaloWidth)
                 .withTextSize(size)
-                .withTextJustify(TEXT_JUSTIFY_CENTER)
-                .withTextAnchor(TEXT_ANCHOR_CENTER)
+                .withTextJustify(textJustify)
+                .withTextAnchor(textAnchor)
+                .withTextOffset(textOffset)
         }
 
         val symbol = symbolManager.create(symbolOptions)

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
@@ -89,9 +89,7 @@ fun Symbol(
         if (isDraggable) {
             symbolManager.addDragListener(
                 object: OnSymbolDragListener {
-                    override fun onAnnotationDragStarted(annotation: Symbol?) {
-
-                    }
+                    override fun onAnnotationDragStarted(annotation: Symbol?) {}
 
                     override fun onAnnotationDrag(annotation: Symbol?) {
                         if (annotation == symbol) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.res.imageResource
 import org.maplibre.android.geometry.LatLng
-import org.maplibre.android.plugins.annotation.OnSymbolDragListener
 import org.maplibre.android.plugins.annotation.Symbol
 import org.maplibre.android.plugins.annotation.SymbolOptions
 import org.maplibre.android.style.layers.Property.ICON_ANCHOR_CENTER
@@ -31,7 +30,6 @@ fun Symbol(
     size: Float,
     color: String,
     isDraggable: Boolean,
-    onDrag: (LatLng) -> Unit = {},
     zIndex: Int = 0,
     imageId: Int? = null,
     imageAnchor: String = ICON_ANCHOR_CENTER,
@@ -85,24 +83,6 @@ fun Symbol(
         }
 
         val symbol = symbolManager.create(symbolOptions)
-
-        if (isDraggable) {
-            symbolManager.addDragListener(
-                object: OnSymbolDragListener {
-                    override fun onAnnotationDragStarted(annotation: Symbol?) {}
-
-                    override fun onAnnotationDrag(annotation: Symbol?) {
-                        if (annotation == symbol) {
-                            annotation?.let {
-                                onDrag(it.latLng)
-                            }
-                        }
-                    }
-
-                    override fun onAnnotationDragFinished(annotation: Symbol?) {}
-                }
-            )
-        }
 
         SymbolNode(symbolManager, symbol)
     }, update = {


### PR DESCRIPTION
For polylines, this changes the isDashed parameter to a dash array, so the user can pass in the type of dash they wish to use. I also added an enum class with 3 basic line types with dash arrays provided.

For symbols, this exposes more icon & text parameters as well as the onDrag callback if the symbol is draggable.

This also adds a onMapClick callback to the MapLibre composable.