### PR TITLE
feat(maplibre): Extend UiSettings with additional properties from MapLibre UiSettings

### DIFF
--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -173,12 +173,47 @@ fun MapLibre(
 }
 
 private fun MapLibreMap.applyUiSettings(uiSettings: UiSettings) {
-    this.uiSettings.setCompassMargins(
-        uiSettings.compassMargins.left,
-        uiSettings.compassMargins.top,
-        uiSettings.compassMargins.right,
-        uiSettings.compassMargins.bottom
-    )
+    this.uiSettings.apply {
+        setAttributionMargins(
+            uiSettings.attributionsMargins.left,
+            uiSettings.attributionsMargins.top,
+            uiSettings.attributionsMargins.right,
+            uiSettings.attributionsMargins.bottom
+        )
+
+        setCompassMargins(
+            uiSettings.compassMargins.left,
+            uiSettings.compassMargins.top,
+            uiSettings.compassMargins.right,
+            uiSettings.compassMargins.bottom
+        )
+
+        setLogoMargins(
+            uiSettings.logoMargins.left,
+            uiSettings.logoMargins.top,
+            uiSettings.logoMargins.right,
+            uiSettings.logoMargins.bottom
+        )
+
+        flingAnimationBaseTime = uiSettings.flingAnimationBaseTime
+        flingThreshold = uiSettings.flingThreshold
+        isAttributionEnabled = uiSettings.isAttributionEnabled
+        isDeselectMarkersOnTap = uiSettings.deselectMarkersOnTap
+        isDisableRotateWhenScaling = uiSettings.disableRotateWhenScaling
+        isDoubleTapGesturesEnabled = uiSettings.doubleTapGesturesEnabled
+        isFlingVelocityAnimationEnabled = uiSettings.flingVelocityAnimationEnabled
+        isHorizontalScrollGesturesEnabled = uiSettings.horizontalScrollGesturesEnabled
+        isIncreaseScaleThresholdWhenRotating = uiSettings.increaseScaleThresholdWhenRotating
+        isLogoEnabled = uiSettings.isLogoEnabled
+        isQuickZoomGesturesEnabled = uiSettings.quickZoomGesturesEnabled
+        isRotateGesturesEnabled = uiSettings.rotateGesturesEnabled
+        isRotateVelocityAnimationEnabled = uiSettings.rotateVelocityAnimationEnabled
+        isScaleVelocityAnimationEnabled = uiSettings.scaleVelocityAnimationEnabled
+        isScrollGesturesEnabled = uiSettings.scrollGesturesEnabled
+        isTiltGesturesEnabled = uiSettings.tiltGesturesEnabled
+        isZoomGesturesEnabled = uiSettings.zoomGesturesEnabled
+        zoomRate = uiSettings.zoomRate
+    }
 }
 
 private fun MapLibreMap.applyProperties(properties: MapProperties) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/UiSettings.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/UiSettings.kt
@@ -12,10 +12,81 @@ package org.ramani.compose
 import android.os.Parcel
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import org.maplibre.android.constants.MapLibreConstants
 
 @Parcelize
-class UiSettings(var compassMargins: CompassMargins = CompassMargins()) : Parcelable {
+class UiSettings(
+    val attributionsMargins: Margins = Margins(),
+    val compassMargins: Margins = Margins(),
+    val deselectMarkersOnTap: Boolean = true,
+    val disableRotateWhenScaling: Boolean = true,
+    val doubleTapGesturesEnabled: Boolean = true,
+    val flingAnimationBaseTime: Long = MapLibreConstants.ANIMATION_DURATION_FLING_BASE,
+    val flingThreshold: Long = MapLibreConstants.VELOCITY_THRESHOLD_IGNORE_FLING,
+    val flingVelocityAnimationEnabled: Boolean = true,
+    val horizontalScrollGesturesEnabled: Boolean = true,
+    val increaseScaleThresholdWhenRotating: Boolean = true,
+    val isAttributionEnabled: Boolean = true,
+    val isLogoEnabled: Boolean = true,
+    val logoMargins: Margins = Margins(),
+    val quickZoomGesturesEnabled: Boolean = true,
+    val rotateGesturesEnabled: Boolean = true,
+    val rotateVelocityAnimationEnabled: Boolean = true,
+    val scaleVelocityAnimationEnabled: Boolean = true,
+    val scrollGesturesEnabled: Boolean = true,
+    val tiltGesturesEnabled: Boolean = true,
+    val zoomGesturesEnabled: Boolean = true,
+    val zoomRate: Float = 1.0f
+) : Parcelable {
     constructor(uiSettings: UiSettings) : this(uiSettings.compassMargins)
+
+    fun copy(
+        attributionsMargins: Margins = this.attributionsMargins,
+        compassMargins: Margins = this.compassMargins,
+        deselectMarkersOnTap: Boolean = this.deselectMarkersOnTap,
+        disableRotateWhenScaling: Boolean = this.disableRotateWhenScaling,
+        doubleTapGesturesEnabled: Boolean = this.doubleTapGesturesEnabled,
+        flingAnimationBaseTime: Long = this.flingAnimationBaseTime,
+        flingThreshold: Long = this.flingThreshold,
+        flingVelocityAnimationEnabled: Boolean = this.flingVelocityAnimationEnabled,
+        horizontalScrollGesturesEnabled: Boolean = this.horizontalScrollGesturesEnabled,
+        increaseScaleThresholdWhenRotating: Boolean = this.increaseScaleThresholdWhenRotating,
+        isAttributionEnabled: Boolean = this.isAttributionEnabled,
+        isLogoEnabled: Boolean = this.isLogoEnabled,
+        logoMargins: Margins = this.logoMargins,
+        quickZoomGesturesEnabled: Boolean = this.quickZoomGesturesEnabled,
+        rotateGesturesEnabled: Boolean = this.rotateGesturesEnabled,
+        rotateVelocityAnimationEnabled: Boolean = this.rotateVelocityAnimationEnabled,
+        scaleVelocityAnimationEnabled: Boolean = this.scaleVelocityAnimationEnabled,
+        scrollGesturesEnabled: Boolean = this.scrollGesturesEnabled,
+        tiltGesturesEnabled: Boolean = this.tiltGesturesEnabled,
+        zoomGesturesEnabled: Boolean = this.zoomGesturesEnabled,
+        zoomRate: Float = this.zoomRate
+    ): UiSettings {
+        return UiSettings(
+            attributionsMargins = attributionsMargins,
+            compassMargins = compassMargins,
+            deselectMarkersOnTap = deselectMarkersOnTap,
+            disableRotateWhenScaling = disableRotateWhenScaling,
+            doubleTapGesturesEnabled = doubleTapGesturesEnabled,
+            flingAnimationBaseTime = flingAnimationBaseTime,
+            flingThreshold = flingThreshold,
+            flingVelocityAnimationEnabled = flingVelocityAnimationEnabled,
+            horizontalScrollGesturesEnabled = horizontalScrollGesturesEnabled,
+            increaseScaleThresholdWhenRotating = increaseScaleThresholdWhenRotating,
+            isAttributionEnabled = isAttributionEnabled,
+            isLogoEnabled = isLogoEnabled,
+            logoMargins = logoMargins,
+            quickZoomGesturesEnabled = quickZoomGesturesEnabled,
+            rotateGesturesEnabled = rotateGesturesEnabled,
+            rotateVelocityAnimationEnabled = rotateVelocityAnimationEnabled,
+            scaleVelocityAnimationEnabled = scaleVelocityAnimationEnabled,
+            scrollGesturesEnabled = scrollGesturesEnabled,
+            tiltGesturesEnabled = tiltGesturesEnabled,
+            zoomGesturesEnabled = zoomGesturesEnabled,
+            zoomRate = zoomRate
+        )
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -23,16 +94,57 @@ class UiSettings(var compassMargins: CompassMargins = CompassMargins()) : Parcel
 
         other as UiSettings
 
-        return compassMargins == other.compassMargins
+        return attributionsMargins == other.attributionsMargins &&
+                deselectMarkersOnTap == other.deselectMarkersOnTap &&
+                disableRotateWhenScaling == other.disableRotateWhenScaling &&
+                doubleTapGesturesEnabled == other.doubleTapGesturesEnabled &&
+                flingAnimationBaseTime == other.flingAnimationBaseTime &&
+                flingThreshold == other.flingThreshold &&
+                flingVelocityAnimationEnabled == other.flingVelocityAnimationEnabled &&
+                horizontalScrollGesturesEnabled == other.horizontalScrollGesturesEnabled &&
+                increaseScaleThresholdWhenRotating == other.increaseScaleThresholdWhenRotating &&
+                isAttributionEnabled == other.isAttributionEnabled &&
+                isLogoEnabled == other.isLogoEnabled &&
+                logoMargins == other.logoMargins &&
+                quickZoomGesturesEnabled == other.quickZoomGesturesEnabled &&
+                rotateGesturesEnabled == other.rotateGesturesEnabled &&
+                rotateVelocityAnimationEnabled == other.rotateVelocityAnimationEnabled &&
+                scaleVelocityAnimationEnabled == other.scaleVelocityAnimationEnabled &&
+                scrollGesturesEnabled == other.scrollGesturesEnabled &&
+                tiltGesturesEnabled == other.tiltGesturesEnabled &&
+                zoomGesturesEnabled == other.zoomGesturesEnabled &&
+                zoomRate == other.zoomRate &&
+                compassMargins == other.compassMargins
     }
 
     override fun hashCode(): Int {
-        return compassMargins.hashCode()
+        var result = attributionsMargins.hashCode()
+        result = 31 * result + compassMargins.hashCode()
+        result = 31 * result + deselectMarkersOnTap.hashCode()
+        result = 31 * result + disableRotateWhenScaling.hashCode()
+        result = 31 * result + doubleTapGesturesEnabled.hashCode()
+        result = 31 * result + flingAnimationBaseTime.hashCode()
+        result = 31 * result + flingThreshold.hashCode()
+        result = 31 * result + flingVelocityAnimationEnabled.hashCode()
+        result = 31 * result + horizontalScrollGesturesEnabled.hashCode()
+        result = 31 * result + increaseScaleThresholdWhenRotating.hashCode()
+        result = 31 * result + isAttributionEnabled.hashCode()
+        result = 31 * result + isLogoEnabled.hashCode()
+        result = 31 * result + logoMargins.hashCode()
+        result = 31 * result + quickZoomGesturesEnabled.hashCode()
+        result = 31 * result + rotateGesturesEnabled.hashCode()
+        result = 31 * result + rotateVelocityAnimationEnabled.hashCode()
+        result = 31 * result + scaleVelocityAnimationEnabled.hashCode()
+        result = 31 * result + scrollGesturesEnabled.hashCode()
+        result = 31 * result + tiltGesturesEnabled.hashCode()
+        result = 31 * result + zoomGesturesEnabled.hashCode()
+        result = 31 * result + zoomRate.hashCode()
+        return result
     }
 }
 
 @Parcelize
-class CompassMargins(val left: Int = 0, val top: Int = 0, val right: Int = 0, val bottom: Int = 0) :
+class Margins(val left: Int = 0, val top: Int = 0, val right: Int = 0, val bottom: Int = 0) :
     Parcelable {
     constructor(parcel: Parcel) : this(
         parcel.readInt(),
@@ -45,7 +157,7 @@ class CompassMargins(val left: Int = 0, val top: Int = 0, val right: Int = 0, va
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as CompassMargins
+        other as Margins
 
         if (left != other.left) return false
         if (top != other.top) return false


### PR DESCRIPTION
This should fixe #88 by providing the `isLogoEnabled` setting and adds more settings from `org.maplibre.android.maps.UiSettings`.

Notes:

- I renamed `CompassMargins` to `Margins` to be able to use it for two more properties
- I made all the properties `val` to support stability in Compose
- Some settings are still missing as it's not trivial to add them to a class annotated with `@Parcelize`
  * attributionDialogManager: AttributionDialogManager
  * setFocalPoint(@Nullable focalPoint: PointF)
  * setCompassImage(@NonNull compass: Drawable)

Resolves #88.