### PR TITLE
feat: add cameraMode options for tracking location changes

### DIFF
--- a/examples/location/app/build.gradle.kts
+++ b/examples/location/app/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3:1.2.1")
-    implementation("org.ramani-maps:ramani-maplibre:0.5.0")
+    implementation("org.ramani-maps:ramani-maplibre:0.7.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/examples/location/app/src/main/java/org/ramani/example/location/MainActivity.kt
+++ b/examples/location/app/src/main/java/org/ramani/example/location/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.location.modes.CameraMode
 import org.maplibre.android.maps.Style
 import org.ramani.compose.CameraPosition
 import org.ramani.compose.LocationRequestProperties
@@ -55,6 +56,7 @@ class MainActivity : ComponentActivity() {
                                 pulseColor = Color.YELLOW,
                             ),
                             userLocation = userLocation,
+                            cameraMode = CameraMode.TRACKING_GPS,
                         )
                     }
                     Button(

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -39,6 +39,7 @@ import org.maplibre.android.gestures.ShoveGestureDetector
 import org.maplibre.android.gestures.StandardScaleGestureDetector
 import org.maplibre.android.location.LocationComponentActivationOptions
 import org.maplibre.android.location.LocationComponentOptions
+import org.maplibre.android.location.OnCameraTrackingChangedListener
 import org.maplibre.android.location.engine.LocationEngineCallback
 import org.maplibre.android.location.engine.LocationEngineDefault
 import org.maplibre.android.location.engine.LocationEngineRequest
@@ -261,6 +262,20 @@ private fun MapLibreMap.setupLocation(
     }
 
     this.locationComponent.renderMode = renderMode
+
+    this.locationComponent.addOnCameraTrackingChangedListener(
+        object : OnCameraTrackingChangedListener {
+            override fun onCameraTrackingDismissed() {
+                // Do nothing
+            }
+
+            override fun onCameraTrackingChanged(currentMode: Int) {
+                if (currentMode != cameraMode) {
+                    locationComponent.cameraMode = cameraMode
+                }
+            }
+    })
+
     this.locationComponent.cameraMode = cameraMode
 }
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -150,7 +150,7 @@ fun MapLibre(
                 currentLocationStyling,
                 userLocation,
                 renderMode,
-                cameraMode
+                cameraMode,
             )
             maplibreMap.addImages(context, currentImages)
             maplibreMap.addSources(currentSources)
@@ -241,7 +241,7 @@ private fun MapLibreMap.setupLocation(
     locationStyling: LocationStyling,
     userLocation: MutableState<Location>?,
     renderMode: Int,
-    cameraMode: Int
+    cameraMode: Int,
 ) {
     if (locationRequestProperties == null) return
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -43,6 +43,7 @@ import org.maplibre.android.location.engine.LocationEngineCallback
 import org.maplibre.android.location.engine.LocationEngineDefault
 import org.maplibre.android.location.engine.LocationEngineRequest
 import org.maplibre.android.location.engine.LocationEngineResult
+import org.maplibre.android.location.modes.CameraMode
 import org.maplibre.android.location.modes.RenderMode
 import org.maplibre.android.maps.MapView
 import org.maplibre.android.maps.MapLibreMap
@@ -85,6 +86,7 @@ annotation class MapLibreComposable
  * @param images Images to be added to the map and used by external layers (pairs of <id, drawable code>).
  * @param renderMode Ways the user location can be rendered on the map.
  * @param onMapLongClick Callback that is invoked when the map is long clicked
+ * @param cameraMode Set specific camera tracking modes as the device location changes.
  * @param content The content of the map.
  */
 @Composable
@@ -106,6 +108,7 @@ fun MapLibre(
     onMapClick: (LatLng) -> Unit = {},
     onMapLongClick: (LatLng) -> Unit = {},
     onStyleLoaded: (Style) -> Unit = {},
+    cameraMode: Int = CameraMode.NONE,
     content: (@Composable @MapLibreComposable () -> Unit)? = null,
 ) {
     if (LocalInspectionMode.current) {
@@ -147,6 +150,7 @@ fun MapLibre(
                 currentLocationStyling,
                 userLocation,
                 renderMode,
+                cameraMode
             )
             maplibreMap.addImages(context, currentImages)
             maplibreMap.addSources(currentSources)
@@ -236,7 +240,8 @@ private fun MapLibreMap.setupLocation(
     locationRequestProperties: LocationRequestProperties?,
     locationStyling: LocationStyling,
     userLocation: MutableState<Location>?,
-    renderMode: Int
+    renderMode: Int,
+    cameraMode: Int
 ) {
     if (locationRequestProperties == null) return
 
@@ -256,6 +261,7 @@ private fun MapLibreMap.setupLocation(
     }
 
     this.locationComponent.renderMode = renderMode
+    this.locationComponent.cameraMode = cameraMode
 }
 
 private fun isFineLocationGranted(context: Context): Boolean {


### PR DESCRIPTION
Allow users to set the `CameraMode` for tracking location changes. CameraMode options and sdk information can be found [here](https://docs.mapbox.com/android/legacy/maps/guides/location-component/#cameramode).

Closes https://github.com/ramani-maps/ramani-maps/issues/72