### PR TITLE
feat(maplibre): Extend UiSettings (compassGravity and logoGravity)

### DIFF
--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -213,6 +213,9 @@ private fun MapLibreMap.applyUiSettings(uiSettings: UiSettings) {
         isTiltGesturesEnabled = uiSettings.tiltGesturesEnabled
         isZoomGesturesEnabled = uiSettings.zoomGesturesEnabled
         zoomRate = uiSettings.zoomRate
+
+        uiSettings.compassGravity?.let { compassGravity = it }
+        uiSettings.logoGravity?.let { logoGravity = it }
     }
 }
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/UiSettings.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/UiSettings.kt
@@ -17,6 +17,7 @@ import org.maplibre.android.constants.MapLibreConstants
 @Parcelize
 class UiSettings(
     val attributionsMargins: Margins = Margins(),
+    val compassGravity: Int? = null,
     val compassMargins: Margins = Margins(),
     val deselectMarkersOnTap: Boolean = true,
     val disableRotateWhenScaling: Boolean = true,
@@ -28,6 +29,7 @@ class UiSettings(
     val increaseScaleThresholdWhenRotating: Boolean = true,
     val isAttributionEnabled: Boolean = true,
     val isLogoEnabled: Boolean = true,
+    val logoGravity: Int? = null,
     val logoMargins: Margins = Margins(),
     val quickZoomGesturesEnabled: Boolean = true,
     val rotateGesturesEnabled: Boolean = true,
@@ -38,10 +40,35 @@ class UiSettings(
     val zoomGesturesEnabled: Boolean = true,
     val zoomRate: Float = 1.0f
 ) : Parcelable {
-    constructor(uiSettings: UiSettings) : this(uiSettings.compassMargins)
+    constructor(uiSettings: UiSettings) : this(
+        attributionsMargins = uiSettings.attributionsMargins,
+        compassGravity = uiSettings.compassGravity,
+        compassMargins = uiSettings.compassMargins,
+        deselectMarkersOnTap = uiSettings.deselectMarkersOnTap,
+        disableRotateWhenScaling = uiSettings.disableRotateWhenScaling,
+        doubleTapGesturesEnabled = uiSettings.doubleTapGesturesEnabled,
+        flingAnimationBaseTime = uiSettings.flingAnimationBaseTime,
+        flingThreshold = uiSettings.flingThreshold,
+        flingVelocityAnimationEnabled = uiSettings.flingVelocityAnimationEnabled,
+        horizontalScrollGesturesEnabled = uiSettings.horizontalScrollGesturesEnabled,
+        increaseScaleThresholdWhenRotating = uiSettings.increaseScaleThresholdWhenRotating,
+        isAttributionEnabled = uiSettings.isAttributionEnabled,
+        isLogoEnabled = uiSettings.isLogoEnabled,
+        logoGravity = uiSettings.logoGravity,
+        logoMargins = uiSettings.logoMargins,
+        quickZoomGesturesEnabled = uiSettings.quickZoomGesturesEnabled,
+        rotateGesturesEnabled = uiSettings.rotateGesturesEnabled,
+        rotateVelocityAnimationEnabled = uiSettings.rotateVelocityAnimationEnabled,
+        scaleVelocityAnimationEnabled = uiSettings.scaleVelocityAnimationEnabled,
+        scrollGesturesEnabled = uiSettings.scrollGesturesEnabled,
+        tiltGesturesEnabled = uiSettings.tiltGesturesEnabled,
+        zoomGesturesEnabled = uiSettings.zoomGesturesEnabled,
+        zoomRate = uiSettings.zoomRate
+    )
 
     fun copy(
         attributionsMargins: Margins = this.attributionsMargins,
+        compassGravity: Int? = this.compassGravity,
         compassMargins: Margins = this.compassMargins,
         deselectMarkersOnTap: Boolean = this.deselectMarkersOnTap,
         disableRotateWhenScaling: Boolean = this.disableRotateWhenScaling,
@@ -53,6 +80,7 @@ class UiSettings(
         increaseScaleThresholdWhenRotating: Boolean = this.increaseScaleThresholdWhenRotating,
         isAttributionEnabled: Boolean = this.isAttributionEnabled,
         isLogoEnabled: Boolean = this.isLogoEnabled,
+        logoGravity: Int? = this.logoGravity,
         logoMargins: Margins = this.logoMargins,
         quickZoomGesturesEnabled: Boolean = this.quickZoomGesturesEnabled,
         rotateGesturesEnabled: Boolean = this.rotateGesturesEnabled,
@@ -65,6 +93,7 @@ class UiSettings(
     ): UiSettings {
         return UiSettings(
             attributionsMargins = attributionsMargins,
+            compassGravity = compassGravity,
             compassMargins = compassMargins,
             deselectMarkersOnTap = deselectMarkersOnTap,
             disableRotateWhenScaling = disableRotateWhenScaling,
@@ -76,6 +105,7 @@ class UiSettings(
             increaseScaleThresholdWhenRotating = increaseScaleThresholdWhenRotating,
             isAttributionEnabled = isAttributionEnabled,
             isLogoEnabled = isLogoEnabled,
+            logoGravity = logoGravity,
             logoMargins = logoMargins,
             quickZoomGesturesEnabled = quickZoomGesturesEnabled,
             rotateGesturesEnabled = rotateGesturesEnabled,
@@ -95,6 +125,8 @@ class UiSettings(
         other as UiSettings
 
         return attributionsMargins == other.attributionsMargins &&
+                compassGravity == other.compassGravity &&
+                compassMargins == other.compassMargins &&
                 deselectMarkersOnTap == other.deselectMarkersOnTap &&
                 disableRotateWhenScaling == other.disableRotateWhenScaling &&
                 doubleTapGesturesEnabled == other.doubleTapGesturesEnabled &&
@@ -105,6 +137,7 @@ class UiSettings(
                 increaseScaleThresholdWhenRotating == other.increaseScaleThresholdWhenRotating &&
                 isAttributionEnabled == other.isAttributionEnabled &&
                 isLogoEnabled == other.isLogoEnabled &&
+                logoGravity == other.logoGravity &&
                 logoMargins == other.logoMargins &&
                 quickZoomGesturesEnabled == other.quickZoomGesturesEnabled &&
                 rotateGesturesEnabled == other.rotateGesturesEnabled &&
@@ -113,12 +146,12 @@ class UiSettings(
                 scrollGesturesEnabled == other.scrollGesturesEnabled &&
                 tiltGesturesEnabled == other.tiltGesturesEnabled &&
                 zoomGesturesEnabled == other.zoomGesturesEnabled &&
-                zoomRate == other.zoomRate &&
-                compassMargins == other.compassMargins
+                zoomRate == other.zoomRate
     }
 
     override fun hashCode(): Int {
         var result = attributionsMargins.hashCode()
+        result = 31 * result + compassGravity.hashCode()
         result = 31 * result + compassMargins.hashCode()
         result = 31 * result + deselectMarkersOnTap.hashCode()
         result = 31 * result + disableRotateWhenScaling.hashCode()
@@ -130,6 +163,7 @@ class UiSettings(
         result = 31 * result + increaseScaleThresholdWhenRotating.hashCode()
         result = 31 * result + isAttributionEnabled.hashCode()
         result = 31 * result + isLogoEnabled.hashCode()
+        result = 31 * result + logoGravity.hashCode()
         result = 31 * result + logoMargins.hashCode()
         result = 31 * result + quickZoomGesturesEnabled.hashCode()
         result = 31 * result + rotateGesturesEnabled.hashCode()


### PR DESCRIPTION
**Enhancement:** Extend `UiSettings` with `compassGravity` and `logoGravity` properties

This PR adds two new properties to `UiSettings`:

- **`compassGravity`**: Controls the alignment of the compass widget.
- **`logoGravity`**: Controls the alignment of the logo widget.

Both properties are set to `null` by default, preserving the existing widget alignment behavior in MapLibre. When `null`, the default gravity settings in MapLibre will apply, ensuring backward compatibility.

#### Purpose
These additions allow for greater customization of widget placement within the map view, giving developers more control over UI layout.
