### PR TITLE
Refactor MapLibre: Move MapView to composable parameter

### DIFF
--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -44,6 +44,7 @@ import org.maplibre.android.location.engine.LocationEngineDefault
 import org.maplibre.android.location.engine.LocationEngineRequest
 import org.maplibre.android.location.engine.LocationEngineResult
 import org.maplibre.android.location.modes.RenderMode
+import org.maplibre.android.maps.MapView
 import org.maplibre.android.maps.MapLibreMap
 import org.maplibre.android.maps.MapLibreMap.OnMoveListener
 import org.maplibre.android.maps.MapLibreMap.OnRotateListener
@@ -100,6 +101,7 @@ fun MapLibre(
     sources: List<Source>? = null,
     layers: List<Layer>? = null,
     images: List<Pair<String, Int>>? = null,
+    mapView: MapView = rememberMapViewWithLifecycle(),
     renderMode: Int = RenderMode.NORMAL,
     onMapClick: (LatLng) -> Unit = {},
     onMapLongClick: (LatLng) -> Unit = {},
@@ -111,8 +113,7 @@ fun MapLibre(
         return
     }
 
-    val context = LocalContext.current
-    val map = rememberMapViewWithLifecycle()
+    val context = LocalContext.current 
     val currentCameraPosition by rememberUpdatedState(cameraPosition)
     val currentUiSettings by rememberUpdatedState(uiSettings)
     val currentMapProperties by rememberUpdatedState(properties)
@@ -125,7 +126,7 @@ fun MapLibre(
     val currentStyleBuilder by rememberUpdatedState(styleBuilder)
     val parentComposition = rememberCompositionContext()
 
-    AndroidView(modifier = modifier, factory = { map })
+    AndroidView(modifier = modifier, factory = { mapView })
     LaunchedEffect(
         currentUiSettings,
         currentMapProperties,

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -134,7 +134,7 @@ fun MapLibre(
         currentLocationStyling
     ) {
         disposingComposition {
-            val maplibreMap = map.awaitMap()
+            val maplibreMap = mapView.awaitMap()
             val style = maplibreMap.awaitStyle(styleBuilder)
             onStyleLoaded(style)
 
@@ -162,7 +162,7 @@ fun MapLibre(
                 true
             }
 
-            map.newComposition(parentComposition, style) {
+            mapView.newComposition(parentComposition, style) {
                 CompositionLocalProvider {
                     MapUpdater(
                         cameraPosition = currentCameraPosition,


### PR DESCRIPTION
This small PR moves the MapView creation outside of the MapLibre composable function, adding it as a parameter with a default value of rememberMapViewWithLifecycle(). This change provides more flexibility in map view management and allows for easier customization and reuse of the map view.

The modification doesn't change the functional behavior but improves the composable's design by making the map view more configurable.
