### PR TITLE
Fix: Updated sources, layers, and images are not passed on to MapLibreMap

### DIFF
--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -137,7 +137,10 @@ fun MapLibre(
         currentMapProperties,
         currentLocationRequestProperties,
         currentLocationEngine,
-        currentLocationStyling
+        currentLocationStyling,
+        currentSources,
+        currentLayers,
+        currentImages,
     ) {
         disposingComposition {
             val maplibreMap = mapView.awaitMap()


### PR DESCRIPTION
I noticed that if I pass new sources, layers, or images to the `MapLibre` composable they won't be passed on to MapLibreMap. This means that I can never update these. Therefore I created this fix. 

Let me know if it makes sense or if it was on purpose that they are not passed as keys to the `LaunchedEffect`.