### PR TITLE
Update maplibre to 11.6.1 and annotation-plugin to 3.0.2

### DIFF
--- a/ramani-maplibre/gradle/libs.versions.toml
+++ b/ramani-maplibre/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ kotlin = "2.0.20"
 kotlin-parcelize = "2.0.20-RC"
 kotlin-gradle-plugin = "2.0.0"
 kotlinx-coroutines-android = "1.8.0"
-maplibre-android-sdk = "11.5.2"
-maplibre-android-plugin-annotation = "3.0.1"
+maplibre-android-sdk = "11.6.1"
+maplibre-android-plugin-annotation = "3.0.2"
 junit = "4.13.2"
 
 [libraries]


### PR DESCRIPTION
This fixes a bug where symbols disappear when the map rotates.