### PR TITLE
fix: a giant marker is being rendered when imageId is null

### DIFF
--- a/ramani-maplibre/src/main/java/org/ramani/compose/CircleWithItem.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/CircleWithItem.kt
@@ -90,7 +90,8 @@ fun CircleWithItem(
             isDraggable = false,
             text = text,
             size = itemSize,
-            zIndex = zIndex + 1
+            zIndex = zIndex + 1,
+            imageId = null
         )
     }
 }


### PR DESCRIPTION
The recent change of having a default `imageId` has resulted in bug where using `CircleWithItem` renders a giant red marker when passing `imageId = null`

Example:

```
@Composable
fun LocationSymbol(item: LiveLocationShare) {
    val location = Location.fromGeoUri(item.lastLocation.location.geoUri) ?: return
    val latLng = LatLng(location.lat, location.lon)

    CircleWithItem(
        center = latLng,
        radius = 10.0F,
        isDraggable = false,
        color = "#F6993A",
        text = item.userId.toString(),
        zIndex = 1,
        itemSize = 12F,
        borderColor = "#4A4A4A",
        borderWidth = 3.0F,
        imageId = null
    )
}
```