### PR TITLE
Fix style reloading and location

### DIFF
--- a/examples/custom-layers/app/src/main/java/org/ramani/example/custom_layers/MainActivity.kt
+++ b/examples/custom-layers/app/src/main/java/org/ramani/example/custom_layers/MainActivity.kt
@@ -4,11 +4,19 @@ import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.maplibre.android.MapLibre
+import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.maps.Style
 import org.maplibre.android.style.expressions.Expression
 import org.maplibre.android.style.layers.FillLayer
@@ -18,11 +26,19 @@ import org.maplibre.android.style.layers.RasterLayer
 import org.maplibre.android.style.sources.GeoJsonSource
 import org.maplibre.android.style.sources.RasterSource
 import org.maplibre.android.style.sources.VectorSource
+import org.ramani.compose.CameraPosition
+import org.ramani.compose.Circle
 import org.ramani.compose.MapLibre
+import org.ramani.compose.Symbol
+import org.ramani.compose.UiSettings
 import org.ramani.example.custom_layers.ui.theme.CustomLayersTheme
 import java.net.URI
 
 class MainActivity : ComponentActivity() {
+    companion object {
+        const val DEFAULT_STYLE_URL = "https://demotiles.maplibre.org/style.json"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -88,6 +104,7 @@ class MainActivity : ComponentActivity() {
             "contours",
             "https://tile.thunderforest.com/thunderforest.outdoors-v2.json?apikey=$thunder_key",
         )
+
         val contourLayer = LineLayer("contour", "contours")
         contourLayer.sourceLayer = "elevation"
 
@@ -97,21 +114,82 @@ class MainActivity : ComponentActivity() {
             "hillshades",
             "https://api.maptiler.com/tiles/hillshade/tiles.json?key=$maptiler_key",
         )
+
         val hillshadeLayer = RasterLayer("hillshades-layer", "hillshades")
 
         setContent {
+            val cameraPosition = rememberSaveable {
+                mutableStateOf(
+                    CameraPosition(target = LatLng(46.6, 7.1), zoom = 8.0)
+                )
+            }
+            val isDefaultStyle = rememberSaveable { mutableStateOf(true) }
+            val styleUrl = rememberSaveable { mutableStateOf(DEFAULT_STYLE_URL) }
+            val styleBuilder = Style.Builder().fromUri(styleUrl.value)
+            val uiSettings = rememberSaveable {
+                mutableStateOf(
+                    UiSettings(rotateGesturesEnabled = false)
+                )
+            }
+
             CustomLayersTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    MapLibre(
+                Box {
+                    Surface(
                         modifier = Modifier.fillMaxSize(),
-                        styleBuilder = Style.Builder()
-                            .fromUri(resources.getString(R.string.maplibre_style_url)),
-                        sources = listOf(nfzSource, contourSource, hillShadeSource),
-                        layers = listOf(nfzFill, nfzPoly, hillshadeLayer, contourLayer),
-                    )
+                        color = MaterialTheme.colorScheme.background
+                    ) {
+                        MapLibre(
+                            modifier = Modifier.fillMaxSize(),
+                            styleBuilder = styleBuilder,
+                            uiSettings = uiSettings.value,
+                            cameraPosition = cameraPosition.value,
+                            sources = listOf(
+                                nfzSource,
+                                contourSource,
+                                hillShadeSource,
+                            ),
+                            layers = listOf(
+                                nfzFill,
+                                nfzPoly,
+                                hillshadeLayer,
+                                contourLayer,
+                            ),
+                        ) {
+                            Symbol(center = LatLng(46.5, 6.4))
+                            Circle(
+                                center = LatLng(46.5, 6.4),
+                                radius = 40F,
+                                isDraggable = true,
+                            )
+                        }
+                    }
+                    Column(
+                        modifier = Modifier.align(Alignment.BottomCenter),
+                    ) {
+                        Button(
+                            modifier = Modifier.align(Alignment.CenterHorizontally),
+                            onClick = {
+                                uiSettings.value =
+                                    UiSettings(rotateGesturesEnabled = !uiSettings.value.rotateGesturesEnabled)
+                            }) {
+                            if (uiSettings.value.rotateGesturesEnabled) {
+                                Text("Disable map rotation")
+                            } else {
+                                Text("Enable map rotation")
+                            }
+                        }
+                        Button(
+                            modifier = Modifier.align(Alignment.CenterHorizontally),
+                            onClick = {
+                                styleUrl.value =
+                                    if (!isDefaultStyle.value) DEFAULT_STYLE_URL
+                                    else resources.getString(R.string.maplibre_style_url)
+
+                                isDefaultStyle.value = !isDefaultStyle.value
+                            }) {
+                            Text("Swap style")
+                        }
+                    }
                 }
             }
         }

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.AbstractApplier
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.MutableState
 import kotlinx.coroutines.awaitCancellation
 import org.maplibre.android.gestures.MoveGestureDetector
 import org.maplibre.android.gestures.RotateGestureDetector
@@ -51,7 +52,7 @@ internal suspend inline fun disposingComposition(factory: () -> Composition) {
 internal fun MapView.newComposition(
     parent: CompositionContext,
     map: MapLibreMap,
-    style: Style,
+    style: MutableState<Style?>,
     content: @Composable () -> Unit,
 ): Composition {
     return Composition(
@@ -79,7 +80,7 @@ private object MapNodeRoot : MapNode
 class MapApplier(
     val map: MapLibreMap,
     val mapView: MapView,
-    val style: Style
+    val style: MutableState<Style?>
 ) : AbstractApplier<MapNode>(MapNodeRoot) {
     private val decorations = mutableListOf<MapNode>()
 
@@ -170,12 +171,12 @@ class MapApplier(
             CircleManager(
                 mapView,
                 map,
-                style,
+                style.value!!,
                 if (it.insertPosition == LayerInsertMethod.INSERT_BELOW) it.referenceLayerId else null,
                 if (it.insertPosition == LayerInsertMethod.INSERT_ABOVE) it.referenceLayerId else null
             )
         } ?: run {
-            CircleManager(mapView, map, style)
+            CircleManager(mapView, map, style.value!!)
         }
 
         circleManagerMap[zIndex] = circleManager
@@ -235,13 +236,13 @@ class MapApplier(
             SymbolManager(
                 mapView,
                 map,
-                style,
+                style.value!!,
                 if (it.insertPosition == LayerInsertMethod.INSERT_BELOW) it.referenceLayerId else null,
                 if (it.insertPosition == LayerInsertMethod.INSERT_ABOVE) it.referenceLayerId else null,
                 null
             )
         } ?: run {
-            SymbolManager(mapView, map, style)
+            SymbolManager(mapView, map, style.value!!)
         }
 
         symbolManager.iconAllowOverlap = true
@@ -285,13 +286,13 @@ class MapApplier(
             FillManager(
                 mapView,
                 map,
-                style,
+                style.value!!,
                 if (it.insertPosition == LayerInsertMethod.INSERT_BELOW) it.referenceLayerId else null,
                 if (it.insertPosition == LayerInsertMethod.INSERT_ABOVE) it.referenceLayerId else null,
                 null
             )
         } ?: run {
-            FillManager(mapView, map, style)
+            FillManager(mapView, map, style.value!!)
         }
 
         if (!zIndexReferenceAnnotationManagerMap.containsKey(zIndex)) {
@@ -309,13 +310,13 @@ class MapApplier(
             LineManager(
                 mapView,
                 map,
-                style,
+                style.value!!,
                 if (it.insertPosition == LayerInsertMethod.INSERT_BELOW) it.referenceLayerId else null,
                 if (it.insertPosition == LayerInsertMethod.INSERT_ABOVE) it.referenceLayerId else null,
                 null
             )
         } ?: run {
-            LineManager(mapView, map, style)
+            LineManager(mapView, map, style.value!!)
         }
 
 

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
@@ -165,18 +165,19 @@ class MapApplier(
     fun getOrCreateCircleManagerForZIndex(zIndex: Int): CircleManager {
         circleManagerMap[zIndex]?.let { return it }
 
+        val style = checkNotNull(style.value)
         val layerInsertInfo = getLayerInsertInfoForZIndex(zIndex)
 
         val circleManager = layerInsertInfo?.let {
             CircleManager(
                 mapView,
                 map,
-                style.value!!,
+                style,
                 if (it.insertPosition == LayerInsertMethod.INSERT_BELOW) it.referenceLayerId else null,
                 if (it.insertPosition == LayerInsertMethod.INSERT_ABOVE) it.referenceLayerId else null
             )
         } ?: run {
-            CircleManager(mapView, map, style.value!!)
+            CircleManager(mapView, map, style)
         }
 
         circleManagerMap[zIndex] = circleManager
@@ -186,29 +187,29 @@ class MapApplier(
         }
 
         circleManager.addDragListener(object : OnCircleDragListener {
-            override fun onAnnotationDragStarted(annotation: Circle?) {
+            override fun onAnnotationDragStarted(annotation: Circle) {
                 decorations.findInputCallback<CircleNode, Circle, Unit>(
-                    nodeMatchPredicate = { it.circle.id == annotation?.id && it.circleManager.layerId == circleManager.layerId },
+                    nodeMatchPredicate = { it.circle.id == annotation.id && it.circleManager.layerId == circleManager.layerId },
                     nodeInputCallback = { onCircleDragged }
-                )?.invoke(annotation!!)
+                )?.invoke(annotation)
             }
 
-            override fun onAnnotationDrag(annotation: Circle?) {
+            override fun onAnnotationDrag(annotation: Circle) {
                 decorations.findInputCallback<CircleNode, Circle, Unit>(
-                    nodeMatchPredicate = { it.circle.id == annotation?.id && it.circleManager.layerId == circleManager.layerId },
+                    nodeMatchPredicate = { it.circle.id == annotation.id && it.circleManager.layerId == circleManager.layerId },
                     nodeInputCallback = { onCircleDragged }
-                )?.invoke(annotation!!)
+                )?.invoke(annotation)
             }
 
-            override fun onAnnotationDragFinished(annotation: Circle?) {
+            override fun onAnnotationDragFinished(annotation: Circle) {
                 decorations.findInputCallback<CircleNode, Circle, Unit>(
-                    nodeMatchPredicate = { it.circle.id == annotation?.id && it.circleManager.layerId == circleManager.layerId },
+                    nodeMatchPredicate = { it.circle.id == annotation.id && it.circleManager.layerId == circleManager.layerId },
                     nodeInputCallback = { onCircleDragStopped }
-                )?.invoke(annotation!!)
+                )?.invoke(annotation)
             }
         })
 
-        return circleManagerMap[zIndex]!!
+        return circleManager
     }
 
     private fun getLayerInsertInfoForZIndex(zIndex: Int): LayerInsertInfo? {
@@ -223,26 +224,28 @@ class MapApplier(
         }.withIndex().minBy { it.value }.index
 
         return LayerInsertInfo(
-            zIndexReferenceAnnotationManagerMap[keys[closestLayerIndex]]?.layerId!!,
+            checkNotNull(zIndexReferenceAnnotationManagerMap[keys[closestLayerIndex]]?.layerId),
             if (zIndex > keys[closestLayerIndex]) LayerInsertMethod.INSERT_ABOVE else LayerInsertMethod.INSERT_BELOW
         )
     }
 
     fun getOrCreateSymbolManagerForZIndex(zIndex: Int): SymbolManager {
         symbolManagerMap[zIndex]?.let { return it }
+
+        val style = checkNotNull(style.value)
         val layerInsertInfo = getLayerInsertInfoForZIndex(zIndex)
 
         val symbolManager = layerInsertInfo?.let {
             SymbolManager(
                 mapView,
                 map,
-                style.value!!,
+                style,
                 if (it.insertPosition == LayerInsertMethod.INSERT_BELOW) it.referenceLayerId else null,
                 if (it.insertPosition == LayerInsertMethod.INSERT_ABOVE) it.referenceLayerId else null,
                 null
             )
         } ?: run {
-            SymbolManager(mapView, map, style.value!!)
+            SymbolManager(mapView, map, style)
         }
 
         symbolManager.iconAllowOverlap = true
@@ -254,25 +257,25 @@ class MapApplier(
         }
 
         symbolManager.addDragListener(object : OnSymbolDragListener {
-            override fun onAnnotationDragStarted(annotation: Symbol?) {
+            override fun onAnnotationDragStarted(annotation: Symbol) {
                 decorations.findInputCallback<SymbolNode, Symbol, Unit>(
-                    nodeMatchPredicate = { it.symbol.id == annotation?.id && it.symbolManager.layerId == symbolManager.layerId },
+                    nodeMatchPredicate = { it.symbol.id == annotation.id && it.symbolManager.layerId == symbolManager.layerId },
                     nodeInputCallback = { onSymbolDragged }
-                )?.invoke(annotation!!)
+                )?.invoke(annotation)
             }
 
-            override fun onAnnotationDrag(annotation: Symbol?) {
+            override fun onAnnotationDrag(annotation: Symbol) {
                 decorations.findInputCallback<SymbolNode, Symbol, Unit>(
-                    nodeMatchPredicate = { it.symbol.id == annotation?.id && it.symbolManager.layerId == symbolManager.layerId },
+                    nodeMatchPredicate = { it.symbol.id == annotation.id && it.symbolManager.layerId == symbolManager.layerId },
                     nodeInputCallback = { onSymbolDragged }
-                )?.invoke(annotation!!)
+                )?.invoke(annotation)
             }
 
-            override fun onAnnotationDragFinished(annotation: Symbol?) {
+            override fun onAnnotationDragFinished(annotation: Symbol) {
                 decorations.findInputCallback<SymbolNode, Symbol, Unit>(
-                    nodeMatchPredicate = { it.symbol.id == annotation?.id && it.symbolManager.layerId == symbolManager.layerId },
+                    nodeMatchPredicate = { it.symbol.id == annotation.id && it.symbolManager.layerId == symbolManager.layerId },
                     nodeInputCallback = { onSymbolDragStopped }
-                )?.invoke(annotation!!)
+                )?.invoke(annotation)
             }
         })
 
@@ -281,18 +284,21 @@ class MapApplier(
 
     fun getOrCreateFillManagerForZIndex(zIndex: Int): FillManager {
         fillManagerMap[zIndex]?.let { return it }
+
+        val style = checkNotNull(style.value)
         val layerInsertInfo = getLayerInsertInfoForZIndex(zIndex)
+
         val fillManager = layerInsertInfo?.let {
             FillManager(
                 mapView,
                 map,
-                style.value!!,
+                style,
                 if (it.insertPosition == LayerInsertMethod.INSERT_BELOW) it.referenceLayerId else null,
                 if (it.insertPosition == LayerInsertMethod.INSERT_ABOVE) it.referenceLayerId else null,
                 null
             )
         } ?: run {
-            FillManager(mapView, map, style.value!!)
+            FillManager(mapView, map, style)
         }
 
         if (!zIndexReferenceAnnotationManagerMap.containsKey(zIndex)) {
@@ -305,18 +311,21 @@ class MapApplier(
 
     fun getOrCreateLineManagerForZIndex(zIndex: Int): LineManager {
         lineManagerMap[zIndex]?.let { return it }
+
+        val style = checkNotNull(style.value)
         val layerInsertInfo = getLayerInsertInfoForZIndex(zIndex)
+
         val lineManager = layerInsertInfo?.let {
             LineManager(
                 mapView,
                 map,
-                style.value!!,
+                style,
                 if (it.insertPosition == LayerInsertMethod.INSERT_BELOW) it.referenceLayerId else null,
                 if (it.insertPosition == LayerInsertMethod.INSERT_ABOVE) it.referenceLayerId else null,
                 null
             )
         } ?: run {
-            LineManager(mapView, map, style.value!!)
+            LineManager(mapView, map, style)
         }
 
 
@@ -329,7 +338,7 @@ class MapApplier(
     }
 
     override fun insertBottomUp(index: Int, instance: MapNode) {
-        // TODO: implement properly
+        // Ignored
     }
 
     override fun insertTopDown(index: Int, instance: MapNode) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
@@ -47,8 +47,8 @@ fun Symbol(
     val mapApplier = currentComposer.applier as MapApplier
 
     imageId?.let {
-        if (mapApplier.style.getImage("$imageId") == null) {
-            mapApplier.style.addImage(
+        if (mapApplier.style.value!!.getImage("$imageId") == null) {
+            mapApplier.style.value!!.addImage(
                 "$imageId",
                 ImageBitmap.imageResource(it).asAndroidBitmap()
             )


### PR DESCRIPTION
This brings a bunch of improvements related to reloading the style and some location features.

@quentinus95, @torrybr: It would be useful if you could try this PR and let me know if it helps some of the issues you reported :pray:.

You should be able to just clone this branch somewhere on your system, and then in your app edit `settings.gradle.kts` to add:

```
includeBuild("/path/to/ramani-maps/ramani-maplibre")
```

This will tell gradle to use the local branch instead of pulling Ramani from Maven.