### PR TITLE
Add clickable functionality and data to circles and symbols

### DIFF
--- a/ramani-maplibre/build.gradle.kts
+++ b/ramani-maplibre/build.gradle.kts
@@ -24,7 +24,7 @@ try {
 
 android {
     namespace = "org.ramani.compose"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 25

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Circle.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Circle.kt
@@ -13,6 +13,8 @@ package org.ramani.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.currentComposer
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.plugins.annotation.CircleOptions
 
@@ -27,8 +29,11 @@ fun Circle(
     borderColor: String = "Black",
     borderWidth: Float = 0.0F,
     zIndex: Int = 0,
+    data: JsonElement = JsonNull.INSTANCE,
     onCenterDragged: (LatLng) -> Unit = {},
     onDragFinished: (LatLng) -> Unit = {},
+    onClick: (JsonElement?) -> Unit = {},
+    onLongClick: (JsonElement?) -> Unit = {}
 ) {
     val mapApplier = currentComposer.applier as MapApplier
 
@@ -42,6 +47,7 @@ fun Circle(
             .withCircleStrokeColor(borderColor)
             .withCircleStrokeWidth(borderWidth)
             .withCircleOpacity(opacity)
+            .withData(data)
 
         val circle = circleManager.create(circleOptions)
 
@@ -50,6 +56,8 @@ fun Circle(
             circle,
             onCircleDragged = { onCenterDragged(it.latLng) },
             onCircleDragStopped = { onDragFinished(it.latLng) },
+            onCircleClicked = { onClick(it.data) },
+            onCircleLongClicked = { onLongClick(it.data) }
         )
     }, update = {
         update(onCenterDragged) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibre.kt
@@ -169,12 +169,12 @@ fun MapLibre(
 
         maplibreMap.addOnMapClickListener { latLng ->
             onMapClick(latLng)
-            true
+            false
         }
 
         maplibreMap.addOnMapLongClickListener { latLng ->
             onMapLongClick(latLng)
-            true
+            false
         }
 
         mapView.newComposition(parentComposition, maplibreMap, currentStyle) {

--- a/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/MapLibreCompose.kt
@@ -209,6 +209,22 @@ class MapApplier(
             }
         })
 
+        circleManager.addClickListener { annotation ->
+            decorations.findInputCallback<CircleNode, Circle, Unit>(
+                nodeMatchPredicate = { it.circle.id == annotation.id && it.circleManager.layerId == circleManager.layerId },
+                nodeInputCallback = { onCircleClicked }
+            )?.invoke(annotation)
+            true
+        }
+
+        circleManager.addLongClickListener { annotation ->
+            decorations.findInputCallback<CircleNode, Circle, Unit>(
+                nodeMatchPredicate = { it.circle.id == annotation.id && it.circleManager.layerId == circleManager.layerId },
+                nodeInputCallback = { onCircleLongClicked }
+            )?.invoke(annotation)
+            true
+        }
+
         return circleManager
     }
 
@@ -278,6 +294,22 @@ class MapApplier(
                 )?.invoke(annotation)
             }
         })
+
+        symbolManager.addClickListener { annotation ->
+            decorations.findInputCallback<SymbolNode, Symbol, Unit>(
+                nodeMatchPredicate = { it.symbol.id == annotation.id && it.symbolManager.layerId == symbolManager.layerId },
+                nodeInputCallback = { onSymbolClicked }
+            )?.invoke(annotation)
+            true
+        }
+
+        symbolManager.addLongClickListener { annotation ->
+            decorations.findInputCallback<SymbolNode, Symbol, Unit>(
+                nodeMatchPredicate = { it.symbol.id == annotation.id && it.symbolManager.layerId == symbolManager.layerId },
+                nodeInputCallback = { onSymbolLongClicked }
+            )?.invoke(annotation)
+            true
+        }
 
         return symbolManager
     }
@@ -373,6 +405,8 @@ internal class CircleNode(
     val circle: Circle,
     var onCircleDragged: (Circle) -> Unit,
     var onCircleDragStopped: (Circle) -> Unit,
+    var onCircleClicked: (Circle) -> Unit,
+    var onCircleLongClicked: (Circle) -> Unit
 ) : MapNode {
     override fun onRemoved() {
         circleManager.delete(circle)
@@ -388,6 +422,8 @@ internal class SymbolNode(
     val symbol: Symbol,
     var onSymbolDragged: (Symbol) -> Unit,
     var onSymbolDragStopped: (Symbol) -> Unit,
+    var onSymbolClicked: (Symbol) -> Unit,
+    var onSymbolLongClicked: (Symbol) -> Unit
 ) : MapNode {
     override fun onRemoved() {
         symbolManager.delete(symbol)

--- a/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
+++ b/ramani-maplibre/src/main/java/org/ramani/compose/Symbol.kt
@@ -16,6 +16,8 @@ import androidx.compose.runtime.currentComposer
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.res.imageResource
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.plugins.annotation.SymbolOptions
 import org.maplibre.android.style.layers.Property.ICON_ANCHOR_CENTER
@@ -41,8 +43,11 @@ fun Symbol(
     textColor: String = "#000000",
     textHaloColor: String = "#000000",
     textHaloWidth: Float = 0f,
+    data: JsonElement = JsonNull.INSTANCE,
     onSymbolDragged: (LatLng) -> Unit = {},
     onDragFinished: (LatLng) -> Unit = {},
+    onClick: (JsonElement?) -> Unit = {},
+    onLongClick: (JsonElement?) -> Unit = {}
 ) {
     val mapApplier = currentComposer.applier as MapApplier
 
@@ -60,6 +65,7 @@ fun Symbol(
         var symbolOptions = SymbolOptions()
             .withDraggable(isDraggable)
             .withLatLng(center)
+            .withData(data)
 
         imageId?.let {
             symbolOptions = symbolOptions
@@ -90,6 +96,8 @@ fun Symbol(
             symbol,
             onSymbolDragged = { onSymbolDragged(it.latLng) },
             onSymbolDragStopped = { onDragFinished(it.latLng) },
+            onSymbolClicked = { onClick(it.data) },
+            onSymbolLongClicked = { onLongClick(it.data) }
         )
     }, update = {
         set(center) {


### PR DESCRIPTION
Hi,

This is a PR which will add `onClick` and `onLongClick` callbacks to circles and symbols.

It works by adding click and long-click handlers to the `CircleManager` and then calling `onClick` and `onLongClick` callbacks provided as arguments to `MapLibre`.

To get it to work I needed to return `false`, rather than `true`, to the map's own click and long click listeners, otherwise the events are not propagated to the annotations.

The PR also adds a new `data` parameter to `Circle` and `Symbol`, allowing arbitrary data to be added to these annotations. These are of type `JsonElement`, matching what is expected by MapLibre's `CircleOptions` and `SymbolOptions`. The `onClick` and `onLongClick` event handlers then receives the data as a (nullable) parameter.

Additionally, to get Ramani to compile with the latest versions of Jetpack dependencies I had to increase the `compileSdk` to 35.

I have provided a demo app at https://github.com/nickw1/ModdedRamaniTest, which demonstrates that the new functionality does not interfere with map click/long click events or dragging. This assumes a local build of Ramani Maps - see the Gradle build file.

Resolves #122.