### PR TITLE
[DOCS] Add docs on using OpenFreeMap with emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ but the idea is this:
 Add the dependency to `build.gradle`:
 
 ```gradle
-implementation 'org.ramani-maps:ramani-maplibre:0.9.0'
+implementation 'org.ramani-maps:ramani-maplibre:0.9.2'
 ```
 
 Insert the map composable:
@@ -31,16 +31,18 @@ MapLibre(modifier = Modifier.fillMaxSize())
 A map will now appear in your app!
 
 If you want to do anything useful though (the free maps are not very detailed),
-you'll either need a commercial tile provider or your own tile hosting.
+you'll either need a commercial tile provider, a free tile provider, or your own tile hosting.
 Several tile providers offer vector tiles with support for MapLibre:
 
 * [MapTiler](https://cloud.maptiler.com/account/keys)
 * [Stadia Maps](https://client.stadiamaps.com/)
+* [OpenFreeMap](https://openfreemap.org)
 
 Note that most vendors require an API key in order to authenticate requests.
 For MapTiler, you must add `?key=YOUR-API-KEY` at the end of the URL,
 and for Stadia Maps, you must add `?api_key=YOUR-API-KEY`.
-Consult your tile provider's documentation for details.
+Consult your tile provider's documentation for details; OpenFreeMap does not
+require an API key.
 
 ## Quick Start with Mapbox
 
@@ -49,6 +51,12 @@ support. There is no plan to work further in that direction. You can still find
 Ramani-Mapbox in the corresponding [release
 tag](https://github.com/ramani-maps/ramani-maps/tree/mapbox-0.1.0), but note
 that it probably won't work with newer versions of Mapbox.
+
+## Quick Start with OpenFreeMap
+
+[OpenFreeMap](https://openfreemap.org) provides completely free map tiles based on [OpenStreetMap](https://openstreetmap.org) data. There are no usage limits and no registration or API key is needed. One important caveat with OpenFreeMap is that if you are using MapLibre Native 11.8.0+ (and by extension, Ramani 0.9.0+) on an *Android emulator* you must use Vulkan as a back end, as otherwise, text and symbols will not be rendered correctly. Please see [the documentation on using Vulkan](README.vulkan.md).
+
+The style URLs to use are documented [on OpenFreeMap](https://openfreemap.org/quick_start).
 
 ## Examples
 

--- a/README.openfreemap.md
+++ b/README.openfreemap.md
@@ -1,0 +1,34 @@
+# Using Ramani Maps with OpenFreeMap
+
+Ramani Maps works very nicely with the [OpenFreeMap](https://www.openfreemap.org) project. There is one caveat: if using Ramani Maps, or indeed MapLibre Native in general, with OpenFreeMap styles, text and symbols do not render correctly on the Android emulator if you are using MapLibre Native 11.8.0+. This affects versions 0.9.0+ of Ramani Maps as they use these recent versions of MapLibre Native.
+
+The rendering is, however, fine on real Android devices.
+
+This is discussed in [issue #3648 on MapLibre Native](https://github.com/maplibre/maplibre-native/issues/3648) and appears to be due to reliability problems with OpenGL emulation. As discussed in this issue, a potential workaround is to use the Vulkan build of MapLibre Native.
+
+By setting up an exclusion in your `build.gradle.kts`, you can force a Vulkan build of MapLibre Native to be used rather than the bundled OpenGL build. Do note that this is not guaranteed to work as it is not the same version of MapLibre Native that Ramani Maps was built with.
+
+## Setting up version catalog
+
+In your `libs.versions.toml` version catalog, you can add a specifier for `maplibreVulkan` in the `versions` section with a version matching the MapLibre Native version that your Ramani version is using, e.g:
+
+```
+maplibreVulkan = "11.11.0"
+```
+
+and then specify the library, e.g.
+
+```
+maplibre-vulkan = { group="org.maplibre.gl", name="android-sdk-vulkan", version.ref="maplibreVulkan" }
+```
+
+## Setting up build.gradle.kts
+
+Then in your `build.gradle.kts`, include the Vulkan version of MapLibre Native, and specify that the bundled version of MapLibre should be *excluded* from the Ramani dependency, e.g.:
+
+```
+implementation(libs.maplibre.vulkan)
+implementation(libs.ramanimaps) {
+    exclude(group = "org.maplibre.gl", module = "android-sdk")
+}
+```

--- a/README.vulkan.md
+++ b/README.vulkan.md
@@ -1,10 +1,8 @@
-# Using Ramani Maps with OpenFreeMap
+# Using Vulkan as a rendering back-end 
 
-Ramani Maps works very nicely with the [OpenFreeMap](https://www.openfreemap.org) project. There is one caveat: if using Ramani Maps, or indeed MapLibre Native in general, with OpenFreeMap styles, text and symbols do not render correctly on the Android emulator if you are using MapLibre Native 11.8.0+. This affects versions 0.9.0+ of Ramani Maps as they use these recent versions of MapLibre Native.
+It is possible with some mapping providers (for example [OpenFreeMap](https://www.openfreemap.org)) that you may encounter problems rendering text and symbols on an emulator with certain versions of MapLibre GL Native, and by extension, Ramani Maps.
 
-The rendering is, however, fine on real Android devices.
-
-This is discussed in [issue #3648 on MapLibre Native](https://github.com/maplibre/maplibre-native/issues/3648) and appears to be due to reliability problems with OpenGL emulation. As discussed in this issue, a potential workaround is to use the Vulkan build of MapLibre Native.
+This is discussed in [issue #3648 on MapLibre Native](https://github.com/maplibre/maplibre-native/issues/3648) and appears to be due to reliability problems with OpenGL emulation. As discussed in this issue, a potential workaround is to use [Vulkan](https://www.vulkan.org) as a back-end, via the Vulkan build of MapLibre Native.
 
 By setting up an exclusion in your `build.gradle.kts`, you can force a Vulkan build of MapLibre Native to be used rather than the bundled OpenGL build. Do note that this is not guaranteed to work as it is not the same version of MapLibre Native that Ramani Maps was built with.
 


### PR DESCRIPTION
Ramani Maps generally works nicely with the free maps provided by the [OpenFreeMap](https://openfreemap.org) project. On a real device there are no issues whatsoever, however on the Android emulator there appear to be some rendering problems with MapLibre Native in general (and hence Ramani Maps) when using recent versions of MapLibre Native 11.8.0+ (and hence Ramani versions 0.9.0+).

This is discussed in [issue #3648 of MapLibre Native](https://github.com/maplibre/maplibre-native/issues/3648) and appears to be due to OpenGL emulation issues. A suggested workaround in that issue is to use the Vulkan build of MapLibre Native instead, and this appears to work for me personally.

This PR adds a document describing the issue and the intended fix. I'm not sure if the ability to allow developers to choose between OpenGL and Vulkan builds can be added to Ramani in general, but for now this document explains the workaround. This involves adding the Vulkan build of MapLibre as a dependency, and excluding the bundled version of MapLibre from Ramani in the `build.gradle.kts`.